### PR TITLE
support loading text prompts

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -216,6 +216,7 @@ class MultiServerMCPClient:
     async def get_prompt(
         self, server_name: str, prompt_name: str, arguments: Optional[dict[str, Any]]
     ) -> list[HumanMessage | AIMessage]:
+        """Get a prompt from a given MCP server."""
         session = self.sessions[server_name]
         return await load_mcp_prompt(session, prompt_name, arguments)
 

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -1,12 +1,14 @@
 from contextlib import AsyncExitStack
 from types import TracebackType
-from typing import Literal, TypedDict, cast
+from typing import Any, Literal, Optional, TypedDict, cast
 
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 
+from langchain_mcp_adapters.prompts import load_mcp_prompt
 from langchain_mcp_adapters.tools import load_mcp_tools
 
 DEFAULT_ENCODING = "utf-8"
@@ -210,6 +212,12 @@ class MultiServerMCPClient:
         for server_tools in self.server_name_to_tools.values():
             all_tools.extend(server_tools)
         return all_tools
+
+    async def get_prompt(
+        self, server_name: str, prompt_name: str, arguments: Optional[dict[str, Any]]
+    ) -> list[HumanMessage | AIMessage]:
+        session = self.sessions[server_name]
+        return await load_mcp_prompt(session, prompt_name, arguments)
 
     async def __aenter__(self) -> "MultiServerMCPClient":
         try:

--- a/langchain_mcp_adapters/prompts.py
+++ b/langchain_mcp_adapters/prompts.py
@@ -1,0 +1,52 @@
+from typing import Any, Optional, Union
+
+from langchain_core.messages import AIMessage, HumanMessage
+from mcp import ClientSession
+from mcp.types import PromptMessage
+
+
+class UnsupportedContentError(Exception):
+    """Raised when a prompt message contains unsupported content."""
+
+    pass
+
+
+def convert_mcp_prompt_message_to_langchain_message(
+    message: PromptMessage,
+) -> Union[HumanMessage, AIMessage]:
+    """Convert an MCP prompt message to a LangChain message.
+
+    Args:
+        message: MCP prompt message to convert
+
+    Returns:
+        a LangChain message
+    """
+    if message.content.type == "text":
+        if message.role == "user":
+            return HumanMessage(content=message.content.text)
+        if message.role == "assistant":
+            return AIMessage(content=message.content.text)
+
+    if message.content.type == "image":
+        image_content = {
+            "type": "image_url",
+            "image_url": {"url": f"data:{message.content.mimeType};base64,{message.content.data}"},
+        }
+        if message.role == "user":
+            return HumanMessage(content=[image_content])
+        if message.role == "assistant":
+            return AIMessage(content=[image_content])
+
+    raise UnsupportedContentError(
+        f"Unsupported prompt message content type: {message.content.type}"
+    )
+
+
+async def load_mcp_prompt(
+    session: ClientSession, name: str, arguments: Optional[dict[str, Any]]
+) -> list[Union[HumanMessage, AIMessage]]:
+    """Load MCP prompt and convert to LangChain messages."""
+    response = await session.get_prompt(name, arguments)
+    results = map(convert_mcp_prompt_message_to_langchain_message, response.messages)
+    return list(results)

--- a/langchain_mcp_adapters/prompts.py
+++ b/langchain_mcp_adapters/prompts.py
@@ -5,18 +5,6 @@ from mcp import ClientSession
 from mcp.types import PromptMessage
 
 
-class UnsupportedContentError(Exception):
-    """Raised when a prompt message contains unsupported content."""
-
-    pass
-
-
-class UnsupportedRoleError(Exception):
-    """Raised when a prompt message contains an unsupported role."""
-
-    pass
-
-
 def convert_mcp_prompt_message_to_langchain_message(
     message: PromptMessage,
 ) -> Union[HumanMessage, AIMessage]:
@@ -34,11 +22,9 @@ def convert_mcp_prompt_message_to_langchain_message(
         elif message.role == "assistant":
             return AIMessage(content=message.content.text)
         else:
-            raise UnsupportedRoleError(f"Unsupported prompt message role: {message.role}")
+            raise ValueError(f"Unsupported prompt message role: {message.role}")
 
-    raise UnsupportedContentError(
-        f"Unsupported prompt message content type: {message.content.type}"
-    )
+    raise ValueError(f"Unsupported prompt message content type: {message.content.type}")
 
 
 async def load_mcp_prompt(

--- a/langchain_mcp_adapters/prompts.py
+++ b/langchain_mcp_adapters/prompts.py
@@ -34,8 +34,7 @@ def convert_mcp_prompt_message_to_langchain_message(
         elif message.role == "assistant":
             return AIMessage(content=message.content.text)
         else:
-            raise UnsupportedRoleError(
-                f"Unsupported prompt message role: {message.role}")
+            raise UnsupportedRoleError(f"Unsupported prompt message role: {message.role}")
 
     raise UnsupportedContentError(
         f"Unsupported prompt message content type: {message.content.type}"

--- a/langchain_mcp_adapters/prompts.py
+++ b/langchain_mcp_adapters/prompts.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from langchain_core.messages import AIMessage, HumanMessage
 from mcp import ClientSession
@@ -7,7 +7,7 @@ from mcp.types import PromptMessage
 
 def convert_mcp_prompt_message_to_langchain_message(
     message: PromptMessage,
-) -> Union[HumanMessage, AIMessage]:
+) -> HumanMessage | AIMessage:
     """Convert an MCP prompt message to a LangChain message.
 
     Args:
@@ -29,7 +29,7 @@ def convert_mcp_prompt_message_to_langchain_message(
 
 async def load_mcp_prompt(
     session: ClientSession, name: str, arguments: Optional[dict[str, Any]] = None
-) -> list[Union[HumanMessage, AIMessage]]:
+) -> list[HumanMessage | AIMessage]:
     """Load MCP prompt and convert to LangChain messages."""
     response = await session.get_prompt(name, arguments)
     return [

--- a/langchain_mcp_adapters/prompts.py
+++ b/langchain_mcp_adapters/prompts.py
@@ -44,7 +44,7 @@ def convert_mcp_prompt_message_to_langchain_message(
 
 
 async def load_mcp_prompt(
-    session: ClientSession, name: str, arguments: Optional[dict[str, Any]]
+    session: ClientSession, name: str, arguments: Optional[dict[str, Any]] = None
 ) -> list[Union[HumanMessage, AIMessage]]:
     """Load MCP prompt and convert to LangChain messages."""
     response = await session.get_prompt(name, arguments)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,11 @@ name = "langchain-mcp-adapters"
 version = "0.0.3"
 description = "Make Anthropic Model Context Protocol (MCP) tools compatible with LangChain and LangGraph agents."
 authors = [
+    { name = "Vadym Barda", email = "19161700+vbarda@users.noreply.github.com " },
 ]
 readme = "README.md"
 requires-python = ">=3.10"
+dependencies = ["langchain-core>=0.3.36", "mcp>=1.2.1"]
 
 [dependency-groups]
 test = [
@@ -24,6 +26,7 @@ test = [
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "-ra -q -v"
+testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 
@@ -33,9 +36,14 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
+    "E", # pycodestyle errors
+    "W", # pycodestyle warnings
+    "F", # pyflakes
+    "I", # isort
+    "B", # flake8-bugbear
 ]
 ignore = [
-  "E501" # line-length
+    "E501", # line-length
 ]
 
 
@@ -45,4 +53,3 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 check_untyped_defs = true
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,9 @@ name = "langchain-mcp-adapters"
 version = "0.0.3"
 description = "Make Anthropic Model Context Protocol (MCP) tools compatible with LangChain and LangGraph agents."
 authors = [
-    {name = "Vadym Barda", email = "19161700+vbarda@users.noreply.github.com "}
 ]
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = [
-    "langchain-core>=0.3.36",
-    "mcp>=1.2.1",
-]
 
 [dependency-groups]
 test = [
@@ -22,15 +17,13 @@ test = [
     "ruff>=0.9.4",
     "mypy>=1.8.0",
     "pytest-socket>=0.7.0",
+    "pytest-asyncio>=0.25.0",
     "types-setuptools>=69.0.0",
 ]
 
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "-ra -q -v"
-testpaths = [
-    "tests",
-]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 
@@ -40,11 +33,6 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    "I",  # isort
-    "B",  # flake8-bugbear
 ]
 ignore = [
   "E501" # line-length

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,3 +1,3 @@
 def test_import() -> None:
     """Test that the code can be imported"""
-    from langchain_mcp_adapters import client, tools  # noqa: F401
+    from langchain_mcp_adapters import client, prompts, tools  # noqa: F401

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -11,7 +11,6 @@ from mcp.types import (
 )
 
 from langchain_mcp_adapters.prompts import (
-    UnsupportedContentError,
     convert_mcp_prompt_message_to_langchain_message,
     load_mcp_prompt,
 )
@@ -44,7 +43,7 @@ def test_convert_mcp_prompt_message_to_langchain_message_with_resource_content(r
             ),
         ),
     )
-    with pytest.raises(UnsupportedContentError):
+    with pytest.raises(ValueError):
         convert_mcp_prompt_message_to_langchain_message(message)
 
 
@@ -53,7 +52,7 @@ def test_convert_mcp_prompt_message_to_langchain_message_with_image_content(role
     message = PromptMessage(
         role=role, content=ImageContent(type="image", mimeType="image/png", data="base64data")
     )
-    with pytest.raises(UnsupportedContentError):
+    with pytest.raises(ValueError):
         convert_mcp_prompt_message_to_langchain_message(message)
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -22,11 +22,12 @@ from langchain_mcp_adapters.prompts import (
     [
         ("assistant", "Hello", AIMessage),
         ("user", "Hello", HumanMessage),
-    ]
+    ],
 )
-def test_convert_mcp_prompt_message_to_langchain_message_with_text_content(role: str, text: str, expected_cls: type):
-    message = PromptMessage(
-        role=role, content=TextContent(type="text", text=text))
+def test_convert_mcp_prompt_message_to_langchain_message_with_text_content(
+    role: str, text: str, expected_cls: type
+):
+    message = PromptMessage(role=role, content=TextContent(type="text", text=text))
     result = convert_mcp_prompt_message_to_langchain_message(message)
     assert isinstance(result, expected_cls)
     assert result.content == text
@@ -50,8 +51,7 @@ def test_convert_mcp_prompt_message_to_langchain_message_with_resource_content(r
 @pytest.mark.parametrize("role", ["assistant", "user"])
 def test_convert_mcp_prompt_message_to_langchain_message_with_image_content(role: str):
     message = PromptMessage(
-        role=role, content=ImageContent(
-            type="image", mimeType="image/png", data="base64data")
+        role=role, content=ImageContent(type="image", mimeType="image/png", data="base64data")
     )
     with pytest.raises(UnsupportedContentError):
         convert_mcp_prompt_message_to_langchain_message(message)
@@ -63,10 +63,8 @@ async def test_load_mcp_prompt():
     session.get_prompt = AsyncMock(
         return_value=AsyncMock(
             messages=[
-                PromptMessage(role="user", content=TextContent(
-                    type="text", text="Hello")),
-                PromptMessage(role="assistant", content=TextContent(
-                    type="text", text="Hi")),
+                PromptMessage(role="user", content=TextContent(type="text", text="Hello")),
+                PromptMessage(role="assistant", content=TextContent(type="text", text="Hi")),
             ]
         )
     )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,85 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from mcp.types import (
+    EmbeddedResource,
+    ImageContent,
+    PromptMessage,
+    TextContent,
+    TextResourceContents,
+)
+
+from langchain_mcp_adapters.prompts import (
+    UnsupportedContentError,
+    convert_mcp_prompt_message_to_langchain_message,
+    load_mcp_prompt,
+)
+
+
+def test_convert_mcp_prompt_message_to_langchain_message_text_user():
+    message = PromptMessage(role="user", content=TextContent(type="text", text="Hello"))
+    result = convert_mcp_prompt_message_to_langchain_message(message)
+    assert isinstance(result, HumanMessage)
+    assert result.content == "Hello"
+
+
+def test_convert_mcp_prompt_message_to_langchain_message_text_assistant():
+    message = PromptMessage(role="assistant", content=TextContent(type="text", text="Hello"))
+    result = convert_mcp_prompt_message_to_langchain_message(message)
+    assert isinstance(result, AIMessage)
+    assert result.content == "Hello"
+
+
+def test_convert_mcp_prompt_message_to_langchain_message_image_user():
+    message = PromptMessage(
+        role="user", content=ImageContent(type="image", mimeType="image/png", data="base64data")
+    )
+    result = convert_mcp_prompt_message_to_langchain_message(message)
+    assert isinstance(result, HumanMessage)
+    assert result.content[0]["type"] == "image_url"
+    assert result.content[0]["image_url"]["url"] == "data:image/png;base64,base64data"
+
+
+def test_convert_mcp_prompt_message_to_langchain_message_image_assistant():
+    message = PromptMessage(
+        role="assistant",
+        content=ImageContent(type="image", mimeType="image/png", data="base64data"),
+    )
+    result = convert_mcp_prompt_message_to_langchain_message(message)
+    assert isinstance(result, AIMessage)
+    assert result.content[0]["type"] == "image_url"
+    assert result.content[0]["image_url"]["url"] == "data:image/png;base64,base64data"
+
+
+def test_convert_mcp_prompt_message_to_langchain_message_unsupported_content():
+    message = PromptMessage(
+        role="user",
+        content=EmbeddedResource(
+            type="resource",
+            resource=TextResourceContents(
+                uri="message://greeting", mimeType="text/plain", text="hi"
+            ),
+        ),
+    )
+    with pytest.raises(UnsupportedContentError):
+        convert_mcp_prompt_message_to_langchain_message(message)
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_prompt():
+    session = AsyncMock()
+    session.get_prompt = AsyncMock(
+        return_value=AsyncMock(
+            messages=[
+                PromptMessage(role="user", content=TextContent(type="text", text="Hello")),
+                PromptMessage(role="assistant", content=TextContent(type="text", text="Hi")),
+            ]
+        )
+    )
+    result = await load_mcp_prompt(session, "test_prompt", None)
+    assert len(result) == 2
+    assert isinstance(result[0], HumanMessage)
+    assert result[0].content == "Hello"
+    assert isinstance(result[1], AIMessage)
+    assert result[1].content == "Hi"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -77,7 +77,7 @@ async def test_load_mcp_prompt():
             ]
         )
     )
-    result = await load_mcp_prompt(session, "test_prompt", None)
+    result = await load_mcp_prompt(session, "test_prompt")
     assert len(result) == 2
     assert isinstance(result[0], HumanMessage)
     assert result[0].content == "Hello"

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12.4'",
@@ -302,6 +303,7 @@ dependencies = [
 test = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-socket" },
     { name = "ruff" },
     { name = "types-setuptools" },
@@ -317,6 +319,7 @@ requires-dist = [
 test = [
     { name = "mypy", specifier = ">=1.8.0" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "ruff", specifier = ">=0.9.4" },
     { name = "types-setuptools", specifier = ">=69.0.0" },
@@ -609,6 +612,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
 ]
 
 [[package]]


### PR DESCRIPTION
details in #11 

any feedback welcome, including nits :)

usage example:

```python
# math_server.py
from mcp.server.fastmcp import FastMCP

mcp = FastMCP("Math")

@mcp.tool()
def add(a: int, b: int) -> int:
    """Add two numbers"""
    return a + b

@mcp.tool()
def multiply(a: int, b: int) -> int:
    """Multiply two numbers"""
    return a * b

@mcp.prompt()
def quiz() -> str:
    return "what's (3 + 5) x 12?"

if __name__ == "__main__":
    mcp.run(transport="stdio")
```

```python
# Create server parameters for stdio connection
from mcp import ClientSession, StdioServerParameters
from mcp.client.stdio import stdio_client

from langchain_mcp_adapters.tools import load_mcp_tools
from langgraph.prebuilt import create_react_agent

from langchain_openai import ChatOpenAI
model = ChatOpenAI(model="gpt-4o")

server_params = StdioServerParameters(
    command="python",
    # Make sure to update to the full absolute path to your math_server.py file
    args=["/path/to/math_server.py"],
)

async with stdio_client(server_params) as (read, write):
    async with ClientSession(read, write) as session:
        # Initialize the connection
        await session.initialize()

        # Get tools
        tools = await load_mcp_tools(session)

        # Get prompt
        messages = await load_mcp_prompt(session, "quiz")

        # Create and run the agent
        agent = create_react_agent(model, tools)
        agent_response = await agent.ainvoke(messages)
```