### PR TITLE
initial mcp resource support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test_watch:
 ######################
 
 # Define a variable for Python and notebook files.
-lint format: PYTHON_FILES=.
+lint format: PYTHON_FILES=langchain_mcp_adapters/ tests/
 lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=. --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
 
 lint lint_diff:

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, Literal, Optional, TypedDict, cast
 
-from langchain_core.documents import Document
-from langchain_core.documents.base import Blob as LCBlob
+from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from mcp import ClientSession, StdioServerParameters
@@ -283,7 +282,7 @@ class MultiServerMCPClient:
         self,
         server_name: str,
         uris: str | list[str] | None = None
-    ) -> list[Document | LCBlob]:
+    ) -> list[Blob]:
         """Get resources from a given MCP server.
 
         Args:
@@ -291,7 +290,7 @@ class MultiServerMCPClient:
             uris: Optional resource URI or list of URIs to load. If not provided, all resources will be loaded.
 
         Returns:
-            A list of LangChain Documents or Blobs
+            A list of LangChain Blobs
         """
         session = self.sessions[server_name]
         return await load_mcp_resources(session, uris)

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -2,6 +2,7 @@ from contextlib import AsyncExitStack
 from types import TracebackType
 from typing import Any, Literal, Optional, TypedDict, cast
 
+from langchain_core.documents import Document
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from mcp import ClientSession, StdioServerParameters
@@ -9,6 +10,7 @@ from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 
 from langchain_mcp_adapters.prompts import load_mcp_prompt
+from langchain_mcp_adapters.resources import load_mcp_resources
 from langchain_mcp_adapters.tools import load_mcp_tools
 
 DEFAULT_ENCODING = "utf-8"
@@ -245,6 +247,23 @@ class MultiServerMCPClient:
         """Get a prompt from a given MCP server."""
         session = self.sessions[server_name]
         return await load_mcp_prompt(session, prompt_name, arguments)
+
+    async def get_resources(
+        self,
+        server_name: str,
+        uris: str | list[str] | None = None
+    ) -> list[Document]:
+        """Get resources from a given MCP server.
+
+        Args:
+            server_name: Name of the server to get resources from
+            uris: Optional resource URI or list of URIs to load. If not provided, all resources will be loaded.
+
+        Returns:
+            A list of LangChain Documents
+        """
+        session = self.sessions[server_name]
+        return await load_mcp_resources(session, uris)
 
     async def __aenter__(self) -> "MultiServerMCPClient":
         try:

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -5,6 +5,7 @@ from types import TracebackType
 from typing import Any, Literal, Optional, TypedDict, cast
 
 from langchain_core.documents import Document
+from langchain_core.documents.base import Blob as LCBlob
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from mcp import ClientSession, StdioServerParameters
@@ -282,7 +283,7 @@ class MultiServerMCPClient:
         self,
         server_name: str,
         uris: str | list[str] | None = None
-    ) -> list[Document]:
+    ) -> list[Document | LCBlob]:
         """Get resources from a given MCP server.
 
         Args:
@@ -290,7 +291,7 @@ class MultiServerMCPClient:
             uris: Optional resource URI or list of URIs to load. If not provided, all resources will be loaded.
 
         Returns:
-            A list of LangChain Documents
+            A list of LangChain Documents or Blobs
         """
         session = self.sessions[server_name]
         return await load_mcp_resources(session, uris)

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -279,9 +279,7 @@ class MultiServerMCPClient:
         return await load_mcp_prompt(session, prompt_name, arguments)
 
     async def get_resources(
-        self,
-        server_name: str,
-        uris: str | list[str] | None = None
+        self, server_name: str, uris: str | list[str] | None = None
     ) -> list[Blob]:
         """Get resources from a given MCP server.
 

--- a/langchain_mcp_adapters/resources.py
+++ b/langchain_mcp_adapters/resources.py
@@ -16,7 +16,7 @@ def convert_mcp_resource_to_langchain_blob(
         contents: The resource contents
 
     Returns:
-        A LangChain Document for text content, or a Blob for binary content
+        A LangChain Blob
     """
     if isinstance(contents, TextResourceContents):
         data = contents.text
@@ -28,15 +28,11 @@ def convert_mcp_resource_to_langchain_blob(
     return Blob.from_data(
         data=data,
         mime_type=contents.mimeType,
-        metadata={
-            "uri": resource_uri
-        },
+        metadata={"uri": resource_uri},
     )
 
-async def get_mcp_resource(
-    session: ClientSession,
-    uri: str
-) -> list[Blob]:
+
+async def get_mcp_resource(session: ClientSession, uri: str) -> list[Blob]:
     """Fetch a single MCP resource and convert it to LangChain Blobs.
 
     Args:

--- a/langchain_mcp_adapters/resources.py
+++ b/langchain_mcp_adapters/resources.py
@@ -1,0 +1,93 @@
+from langchain_core.documents import Document
+from mcp import ClientSession
+from mcp.types import BlobResourceContents, ResourceContents, TextResourceContents
+
+
+def convert_mcp_resource_to_langchain_document(
+    resource_uri: str,
+    contents: ResourceContents,
+) -> Document:
+    """Convert an MCP resource content to a LangChain Document.
+
+    Args:
+        resource_uri: URI of the resource
+        contents: The resource contents
+
+    Returns:
+        A LangChain Document
+    """
+    metadata = {
+        "uri": resource_uri,
+        "mime_type": contents.mimeType,
+    }
+
+    content = ""
+
+    if isinstance(contents, TextResourceContents):
+        content = contents.text
+    elif isinstance(contents, BlobResourceContents):
+        metadata["blob_data"] = contents.blob
+        content = f"Binary data of type: {contents.mimeType}"
+
+    return Document(page_content=content, metadata=metadata)
+
+async def get_mcp_resource(
+    session: ClientSession,
+    uri: str
+) -> list[Document]:
+    """Fetch a single MCP resource and convert it to LangChain Documents.
+
+    Args:
+        session: MCP client session
+        uri: URI of the resource to fetch
+
+    Returns:
+        A list of LangChain Documents, one for each content in the resource
+    """
+    contents_result = await session.read_resource(uri)
+
+    documents = []
+
+    if not contents_result.contents or len(contents_result.contents) == 0:
+        return documents
+
+    for content in contents_result.contents:
+        doc = convert_mcp_resource_to_langchain_document(uri, content)
+        documents.append(doc)
+
+    return documents
+
+
+async def load_mcp_resources(
+    session: ClientSession,
+    uris: str | list[str] | None = None,
+) -> list[Document]:
+    """Load MCP resources and convert them to LangChain Documents.
+
+    This is the main function that should be used by external code.
+
+    Args:
+        session: MCP client session
+        uris: Optional resource URI or list of URIs to load. If not provided, all resources will be loaded.
+
+    Returns:
+        A list of LangChain Documents
+    """
+    documents = []
+
+    if uris is None:
+        resources_list = await session.list_resources()
+        uri_list = [r.uri for r in resources_list.resources]
+    elif isinstance(uris, str):
+        uri_list = [uris]
+    else:
+        uri_list = uris
+
+    for uri in uri_list:
+        try:
+            resource_docs = await get_mcp_resource(session, uri)
+            documents.extend(resource_docs)
+        except Exception as e:
+            print(f"Error fetching resource {uri}: {e}")
+
+    return documents

--- a/langchain_mcp_adapters/resources.py
+++ b/langchain_mcp_adapters/resources.py
@@ -43,25 +43,32 @@ async def get_mcp_resource(session: ClientSession, uri: str) -> list[Blob]:
         A list of LangChain Blobs
     """
     contents_result = await session.read_resource(uri)
-
-    documents = []
-
     if not contents_result.contents or len(contents_result.contents) == 0:
-        return documents
+        return []
 
-    for content in contents_result.contents:
-        doc = convert_mcp_resource_to_langchain_blob(uri, content)
-        documents.append(doc)
-
-    return documents
+    return [
+        convert_mcp_resource_to_langchain_blob(uri, content) for content in contents_result.contents
+    ]
 
 
 async def load_mcp_resources(
     session: ClientSession,
     uris: str | list[str] | None = None,
 ) -> list[Blob]:
-    """Load MCP resources and convert them to LangChain Blobs"""
-    documents = []
+    """Load MCP resources and convert them to LangChain Blobs.
+
+    Args:
+        session: MCP client session
+        uris: List of URIs to load.
+            If None, all resources will be loaded.
+            NOTE: if you specify None, dynamic resources will NOT be loaded,
+            as they need the parameters to be provided,
+            and are ignored by MCP SDK's session.list_resources() method.
+
+    Returns:
+        A list of LangChain Blobs
+    """
+    blobs = []
 
     if uris is None:
         resources_list = await session.list_resources()
@@ -73,9 +80,9 @@ async def load_mcp_resources(
 
     for uri in uri_list:
         try:
-            resource_docs = await get_mcp_resource(session, uri)
-            documents.extend(resource_docs)
+            resource_blobs = await get_mcp_resource(session, uri)
+            blobs.extend(resource_blobs)
         except Exception as e:
             raise RuntimeError(f"Error fetching resource {uri}") from e
 
-    return documents
+    return blobs

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,3 +1,3 @@
 def test_import() -> None:
     """Test that the code can be imported"""
-    from langchain_mcp_adapters import client, prompts, tools  # noqa: F401
+    from langchain_mcp_adapters import client, prompts, resources, tools  # noqa: F401

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -21,11 +21,7 @@ from langchain_mcp_adapters.resources import (
 
 def test_convert_mcp_resource_to_langchain_blob_with_text():
     uri = "file:///test.txt"
-    contents = TextResourceContents(
-        uri=uri,
-        mimeType="text/plain",
-        text="Hello, world!"
-    )
+    contents = TextResourceContents(uri=uri, mimeType="text/plain", text="Hello, world!")
 
     blob = convert_mcp_resource_to_langchain_blob(uri, contents)
 
@@ -40,11 +36,7 @@ def test_convert_mcp_resource_to_langchain_blob():
     original_data = b"binary-image-data"
     base64_blob = base64.b64encode(original_data).decode()
 
-    contents = BlobResourceContents(
-        uri=uri,
-        mimeType="image/png",
-        blob=base64_blob
-    )
+    contents = BlobResourceContents(uri=uri, mimeType="image/png", blob=base64_blob)
 
     blob = convert_mcp_resource_to_langchain_blob(uri, contents)
 
@@ -59,10 +51,7 @@ def test_convert_mcp_resource_to_langchain_blob_with_invalid_type():
         pass
 
     with pytest.raises(ValueError):
-        convert_mcp_resource_to_langchain_blob(
-            "file:///dummy",
-            DummyContent()
-        )
+        convert_mcp_resource_to_langchain_blob("file:///dummy", DummyContent())
 
 
 @pytest.mark.asyncio
@@ -73,16 +62,8 @@ async def test_get_mcp_resource_with_contents():
     session.read_resource = AsyncMock(
         return_value=ReadResourceResult(
             contents=[
-                TextResourceContents(
-                    uri=uri,
-                    mimeType="text/plain",
-                    text="Content 1"
-                ),
-                TextResourceContents(
-                    uri=uri,
-                    mimeType="text/plain",
-                    text="Content 2"
-                )
+                TextResourceContents(uri=uri, mimeType="text/plain", text="Content 1"),
+                TextResourceContents(uri=uri, mimeType="text/plain", text="Content 2"),
             ]
         )
     )
@@ -106,16 +87,10 @@ async def test_get_mcp_resource_with_text_and_blob():
     session.read_resource = AsyncMock(
         return_value=ReadResourceResult(
             contents=[
-                TextResourceContents(
-                    uri=uri,
-                    mimeType="text/plain",
-                    text="Hello Text"
-                ),
+                TextResourceContents(uri=uri, mimeType="text/plain", text="Hello Text"),
                 BlobResourceContents(
-                    uri=uri,
-                    mimeType="application/octet-stream",
-                    blob=base64_blob
-                )
+                    uri=uri, mimeType="application/octet-stream", blob=base64_blob
+                ),
             ]
         )
     )
@@ -138,9 +113,7 @@ async def test_get_mcp_resource_with_empty_contents():
     session = AsyncMock()
     uri = "file:///empty.txt"
 
-    session.read_resource = AsyncMock(
-        return_value=ReadResourceResult(contents=[])
-    )
+    session.read_resource = AsyncMock(return_value=ReadResourceResult(contents=[]))
 
     docs = await get_mcp_resource(session, uri)
 
@@ -158,22 +131,14 @@ async def test_load_mcp_resources_with_list_of_uris():
     session.read_resource.side_effect = [
         ReadResourceResult(
             contents=[
-                TextResourceContents(
-                    uri=uri1,
-                    mimeType="text/plain",
-                    text="Content from test1"
-                )
+                TextResourceContents(uri=uri1, mimeType="text/plain", text="Content from test1")
             ]
         ),
         ReadResourceResult(
             contents=[
-                TextResourceContents(
-                    uri=uri2,
-                    mimeType="text/plain",
-                    text="Content from test2"
-                )
+                TextResourceContents(uri=uri2, mimeType="text/plain", text="Content from test2")
             ]
-        )
+        ),
     ]
 
     docs = await load_mcp_resources(session, [uri1, uri2])
@@ -186,6 +151,7 @@ async def test_load_mcp_resources_with_list_of_uris():
     assert docs[1].metadata["uri"] == uri2
     assert session.read_resource.call_count == 2
 
+
 @pytest.mark.asyncio
 async def test_load_mcp_resources_with_single_uri_string():
     session = AsyncMock()
@@ -194,11 +160,7 @@ async def test_load_mcp_resources_with_single_uri_string():
     session.read_resource = AsyncMock(
         return_value=ReadResourceResult(
             contents=[
-                TextResourceContents(
-                    uri=uri,
-                    mimeType="text/plain",
-                    text="Content from test"
-                )
+                TextResourceContents(uri=uri, mimeType="text/plain", text="Content from test")
             ]
         )
     )
@@ -211,6 +173,7 @@ async def test_load_mcp_resources_with_single_uri_string():
     assert docs[0].metadata["uri"] == uri
     session.read_resource.assert_called_once_with(uri)
 
+
 @pytest.mark.asyncio
 async def test_load_mcp_resources_with_all_resources():
     session = AsyncMock()
@@ -218,16 +181,8 @@ async def test_load_mcp_resources_with_all_resources():
     session.list_resources = AsyncMock(
         return_value=ListResourcesResult(
             resources=[
-                Resource(
-                    uri="file:///test1.txt",
-                    name="test1.txt",
-                    mimeType="text/plain"
-                ),
-                Resource(
-                    uri="file:///test2.txt",
-                    name="test2.txt",
-                    mimeType="text/plain"
-                )
+                Resource(uri="file:///test1.txt", name="test1.txt", mimeType="text/plain"),
+                Resource(uri="file:///test2.txt", name="test2.txt", mimeType="text/plain"),
             ]
         )
     )
@@ -237,21 +192,17 @@ async def test_load_mcp_resources_with_all_resources():
         ReadResourceResult(
             contents=[
                 TextResourceContents(
-                    uri="file:///test1.txt",
-                    mimeType="text/plain",
-                    text="Content from test1"
+                    uri="file:///test1.txt", mimeType="text/plain", text="Content from test1"
                 )
             ]
         ),
         ReadResourceResult(
             contents=[
                 TextResourceContents(
-                    uri="file:///test2.txt",
-                    mimeType="text/plain",
-                    text="Content from test2"
+                    uri="file:///test2.txt", mimeType="text/plain", text="Content from test2"
                 )
             ]
-        )
+        ),
     ]
 
     docs = await load_mcp_resources(session)
@@ -262,6 +213,7 @@ async def test_load_mcp_resources_with_all_resources():
     assert session.list_resources.called
     assert session.read_resource.call_count == 2
 
+
 @pytest.mark.asyncio
 async def test_load_mcp_resources_with_error_handling():
     session = AsyncMock()
@@ -271,21 +223,16 @@ async def test_load_mcp_resources_with_error_handling():
     session.read_resource = AsyncMock()
     session.read_resource.side_effect = [
         ReadResourceResult(
-            contents=[
-                TextResourceContents(
-                    uri=uri1,
-                    mimeType="text/plain",
-                    text="Valid content"
-                )
-            ]
+            contents=[TextResourceContents(uri=uri1, mimeType="text/plain", text="Valid content")]
         ),
-        Exception("Resource not found")
+        Exception("Resource not found"),
     ]
 
     with pytest.raises(RuntimeError) as exc_info:
         await load_mcp_resources(session, [uri1, uri2])
 
     assert "Error fetching resource" in str(exc_info.value)
+
 
 @pytest.mark.asyncio
 async def test_load_mcp_resources_with_blob_content():
@@ -297,11 +244,7 @@ async def test_load_mcp_resources_with_blob_content():
     session.read_resource = AsyncMock(
         return_value=ReadResourceResult(
             contents=[
-                BlobResourceContents(
-                    uri=uri,
-                    mimeType="application/octet-stream",
-                    blob=base64_blob
-                )
+                BlobResourceContents(uri=uri, mimeType="application/octet-stream", blob=base64_blob)
             ]
         )
     )

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -68,12 +68,12 @@ async def test_get_mcp_resource_with_contents():
         )
     )
 
-    docs = await get_mcp_resource(session, uri)
+    blobs = await get_mcp_resource(session, uri)
 
-    assert len(docs) == 2
-    assert all(isinstance(d, Blob) for d in docs)
-    assert docs[0].data == "Content 1"
-    assert docs[1].data == "Content 2"
+    assert len(blobs) == 2
+    assert all(isinstance(d, Blob) for d in blobs)
+    assert blobs[0].data == "Content 1"
+    assert blobs[1].data == "Content 2"
 
 
 @pytest.mark.asyncio
@@ -115,9 +115,9 @@ async def test_get_mcp_resource_with_empty_contents():
 
     session.read_resource = AsyncMock(return_value=ReadResourceResult(contents=[]))
 
-    docs = await get_mcp_resource(session, uri)
+    blobs = await get_mcp_resource(session, uri)
 
-    assert len(docs) == 0
+    assert len(blobs) == 0
     session.read_resource.assert_called_once_with(uri)
 
 
@@ -141,14 +141,14 @@ async def test_load_mcp_resources_with_list_of_uris():
         ),
     ]
 
-    docs = await load_mcp_resources(session, [uri1, uri2])
+    blobs = await load_mcp_resources(session, [uri1, uri2])
 
-    assert len(docs) == 2
-    assert all(isinstance(d, Blob) for d in docs)
-    assert docs[0].data == "Content from test1"
-    assert docs[1].data == "Content from test2"
-    assert docs[0].metadata["uri"] == uri1
-    assert docs[1].metadata["uri"] == uri2
+    assert len(blobs) == 2
+    assert all(isinstance(d, Blob) for d in blobs)
+    assert blobs[0].data == "Content from test1"
+    assert blobs[1].data == "Content from test2"
+    assert blobs[0].metadata["uri"] == uri1
+    assert blobs[1].metadata["uri"] == uri2
     assert session.read_resource.call_count == 2
 
 
@@ -165,12 +165,12 @@ async def test_load_mcp_resources_with_single_uri_string():
         )
     )
 
-    docs = await load_mcp_resources(session, uri)
+    blobs = await load_mcp_resources(session, uri)
 
-    assert len(docs) == 1
-    assert isinstance(docs[0], Blob)
-    assert docs[0].data == "Content from test"
-    assert docs[0].metadata["uri"] == uri
+    assert len(blobs) == 1
+    assert isinstance(blobs[0], Blob)
+    assert blobs[0].data == "Content from test"
+    assert blobs[0].metadata["uri"] == uri
     session.read_resource.assert_called_once_with(uri)
 
 
@@ -205,11 +205,11 @@ async def test_load_mcp_resources_with_all_resources():
         ),
     ]
 
-    docs = await load_mcp_resources(session)
+    blobs = await load_mcp_resources(session)
 
-    assert len(docs) == 2
-    assert docs[0].data == "Content from test1"
-    assert docs[1].data == "Content from test2"
+    assert len(blobs) == 2
+    assert blobs[0].data == "Content from test1"
+    assert blobs[1].data == "Content from test2"
     assert session.list_resources.called
     assert session.read_resource.call_count == 2
 
@@ -249,9 +249,9 @@ async def test_load_mcp_resources_with_blob_content():
         )
     )
 
-    docs = await load_mcp_resources(session, uri)
+    blobs = await load_mcp_resources(session, uri)
 
-    assert len(docs) == 1
-    assert isinstance(docs[0], Blob)
-    assert docs[0].data == original_data
-    assert docs[0].mimetype == "application/octet-stream"
+    assert len(blobs) == 1
+    assert isinstance(blobs[0], Blob)
+    assert blobs[0].data == original_data
+    assert blobs[0].mimetype == "application/octet-stream"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,240 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain_core.documents import Document
+from mcp.types import (
+    BlobResourceContents,
+    ListResourcesResult,
+    ReadResourceResult,
+    Resource,
+    TextResourceContents,
+)
+
+from langchain_mcp_adapters.resources import (
+    convert_mcp_resource_to_langchain_document,
+    get_mcp_resource,
+    load_mcp_resources,
+)
+
+
+def test_convert_mcp_resource_to_langchain_document_with_text():
+    uri = "file:///test.txt"
+    contents = TextResourceContents(
+        uri=uri,
+        mimeType="text/plain",
+        text="Hello, world!"
+    )
+
+    doc = convert_mcp_resource_to_langchain_document(uri, contents)
+
+    assert isinstance(doc, Document)
+    assert doc.page_content == "Hello, world!"
+    assert doc.metadata["uri"] == uri
+    assert doc.metadata["mime_type"] == "text/plain"
+
+
+def test_convert_mcp_resource_to_langchain_document_with_blob():
+    uri = "file:///test.png"
+    contents = BlobResourceContents(
+        uri=uri,
+        mimeType="image/png",
+        blob="base64data"
+    )
+
+    doc = convert_mcp_resource_to_langchain_document(uri, contents)
+
+    assert isinstance(doc, Document)
+    assert doc.page_content == "Binary data of type: image/png"
+    assert doc.metadata["uri"] == uri
+    assert doc.metadata["mime_type"] == "image/png"
+    assert doc.metadata["blob_data"] == "base64data"
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_resource_with_contents():
+    session = AsyncMock()
+    uri = "file:///test.txt"
+
+    session.read_resource = AsyncMock(
+        return_value=ReadResourceResult(
+            contents=[
+                TextResourceContents(
+                    uri=uri,
+                    mimeType="text/plain",
+                    text="Content 1"
+                ),
+                TextResourceContents(
+                    uri=uri,
+                    mimeType="text/plain",
+                    text="Content 2"
+                )
+            ]
+        )
+    )
+
+    docs = await get_mcp_resource(session, uri)
+
+    assert len(docs) == 2
+    assert docs[0].page_content == "Content 1"
+    assert docs[1].page_content == "Content 2"
+    assert docs[0].metadata["uri"] == uri
+    assert docs[1].metadata["uri"] == uri
+    session.read_resource.assert_called_once_with(uri)
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_resource_with_empty_contents():
+    session = AsyncMock()
+    uri = "file:///empty.txt"
+
+    session.read_resource = AsyncMock(
+        return_value=ReadResourceResult(contents=[])
+    )
+
+    docs = await get_mcp_resource(session, uri)
+
+    assert len(docs) == 0
+    session.read_resource.assert_called_once_with(uri)
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_resources_with_list_of_uris():
+    session = AsyncMock()
+    uri1 = "file:///test1.txt"
+    uri2 = "file:///test2.txt"
+
+    session.read_resource = AsyncMock()
+    session.read_resource.side_effect = [
+        ReadResourceResult(
+            contents=[
+                TextResourceContents(
+                    uri=uri1,
+                    mimeType="text/plain",
+                    text="Content from test1"
+                )
+            ]
+        ),
+        ReadResourceResult(
+            contents=[
+                TextResourceContents(
+                    uri=uri2,
+                    mimeType="text/plain",
+                    text="Content from test2"
+                )
+            ]
+        )
+    ]
+
+    docs = await load_mcp_resources(session, [uri1, uri2])
+
+    assert len(docs) == 2
+    assert docs[0].page_content == "Content from test1"
+    assert docs[1].page_content == "Content from test2"
+    assert docs[0].metadata["uri"] == uri1
+    assert docs[1].metadata["uri"] == uri2
+    assert session.read_resource.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_resources_with_single_uri_string():
+    session = AsyncMock()
+    uri = "file:///test.txt"
+
+    session.read_resource = AsyncMock(
+        return_value=ReadResourceResult(
+            contents=[
+                TextResourceContents(
+                    uri=uri,
+                    mimeType="text/plain",
+                    text="Content from test"
+                )
+            ]
+        )
+    )
+
+    docs = await load_mcp_resources(session, uri)
+
+    assert len(docs) == 1
+    assert docs[0].page_content == "Content from test"
+    assert docs[0].metadata["uri"] == uri
+    session.read_resource.assert_called_once_with(uri)
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_resources_with_all_resources():
+    session = AsyncMock()
+
+    session.list_resources = AsyncMock(
+        return_value=ListResourcesResult(
+            resources=[
+                Resource(
+                    uri="file:///test1.txt",
+                    name="test1.txt",
+                    mimeType="text/plain"
+                ),
+                Resource(
+                    uri="file:///test2.txt",
+                    name="test2.txt",
+                    mimeType="text/plain"
+                )
+            ]
+        )
+    )
+
+    session.read_resource = AsyncMock()
+    session.read_resource.side_effect = [
+        ReadResourceResult(
+            contents=[
+                TextResourceContents(
+                    uri="file:///test1.txt",
+                    mimeType="text/plain",
+                    text="Content from test1"
+                )
+            ]
+        ),
+        ReadResourceResult(
+            contents=[
+                TextResourceContents(
+                    uri="file:///test2.txt",
+                    mimeType="text/plain",
+                    text="Content from test2"
+                )
+            ]
+        )
+    ]
+
+    docs = await load_mcp_resources(session)
+
+    assert len(docs) == 2
+    assert docs[0].page_content == "Content from test1"
+    assert docs[1].page_content == "Content from test2"
+    assert session.list_resources.called
+    assert session.read_resource.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_resources_with_error_handling():
+    session = AsyncMock()
+    uri1 = "file:///valid.txt"
+    uri2 = "file:///error.txt"
+
+    session.read_resource = AsyncMock()
+    session.read_resource.side_effect = [
+        ReadResourceResult(
+            contents=[
+                TextResourceContents(
+                    uri=uri1,
+                    mimeType="text/plain",
+                    text="Valid content"
+                )
+            ]
+        ),
+        Exception("Resource not found")
+    ]
+
+    docs = await load_mcp_resources(session, [uri1, uri2])
+
+    assert len(docs) == 1
+    assert docs[0].page_content == "Valid content"
+    assert docs[0].metadata["uri"] == uri1
+    assert session.read_resource.call_count == 2


### PR DESCRIPTION
## Changes
This PR adds functionality to convert MCP resources to LangChain Document objects.

### Key Features
- Added `resources.py` module: MCP resources → LangChain Document conversion functionality
- Resource loading capability with single URI or URI list
- Support for text resources with full content and binary resources (stored as metadata with type indication)
- Added `get_resources` method to `MultiServerMCPClient`

### Testing
- Added unit tests: Tests for conversion functions and loading functions

## Checklist
- [x] Added/modified tests
- [x] Run code lint