### PR TITLE
Minor improvement to typing in client.py

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -275,5 +275,4 @@ class MultiServerMCPClient:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        _, _, _ = exc_type, exc_val, exc_tb
         await self.exit_stack.aclose()


### PR DESCRIPTION
Fixed a couple of minor issues with typing, most notably:
- removed default `= None` in TypedDict
- Add `| None` in `__init__` for connections
- Add comment and `type: ignore` in the `__aenter__` method.


I was going to remove the ambiguous `**kwargs` add overloads to the `connect_to_server`  method, but decided it overcomplicates things too much, and anyway there are the properly typed methods for each specific connection type already. 
Thought I'd just push back these minor changes anyway though.