### PR TITLE
Feat: Disconnect a single server

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -107,7 +107,7 @@ class MultiServerMCPClient:
             ```
         """
         self.connections: dict[str, StdioConnection | SSEConnection] = connections or {}
-        self.exit_stacks =  dict[str, AsyncExitStack] = {}
+        self.exit_stacks:  dict[str, AsyncExitStack] = {}
         self.sessions: dict[str, ClientSession] = {}
         self.server_name_to_tools: dict[str, list[BaseTool]] = {}
 

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -292,7 +292,7 @@ class MultiServerMCPClient:
         self.exit_stacks[server_name] = exit_stack
 
         await self._initialize_session_and_load_tools(server_name, session)
-   
+
     async def connect_to_server_via_websocket(
         self,
         server_name: str,
@@ -320,7 +320,7 @@ class MultiServerMCPClient:
             ) from None
 
         exit_stack = AsyncExitStack()
-        
+
         ws_transport = await exit_stack.enter_async_context(websocket_client(url))
         read, write = ws_transport
         session_kwargs = session_kwargs or {}
@@ -330,7 +330,7 @@ class MultiServerMCPClient:
         )
 
         self.exit_stacks[server_name] = exit_stack
-        
+
         await self._initialize_session_and_load_tools(server_name, session)
 
     async def disconnect_server(
@@ -345,7 +345,7 @@ class MultiServerMCPClient:
             server_name: Name to identify this server connection
 
         """
-        
+
         self.sessions.pop(server_name, None)
         self.server_name_to_tools.pop(server_name, None)
 

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -404,4 +404,3 @@ class MultiServerMCPClient:
     ) -> None:
         for exit_stack in self.exit_stacks.values():
                 await exit_stack.aclose()
-                raise

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -139,7 +139,7 @@ async def test_multi_server_connect_and_disconnect_methods(
         # Check that we have one tool now
         all_tools = client.get_tools()
         assert len(all_tools) == 1
-        
+
         await client.disconnect_server("time")
 
         # Check that we have no tool now

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -73,7 +73,7 @@ async def test_multi_server_mcp_client():
 
 
 @pytest.mark.asyncio
-async def test_multi_server_connect_methods():
+async def test_multi_server_connect_and_disconnect_methods():
     """Test the different connect methods for MultiServerMCPClient."""
 
     # Get the absolute path to the server scripts
@@ -101,6 +101,19 @@ async def test_multi_server_connect_methods():
         # Verify tool names
         tool_names = {tool.name for tool in all_tools}
         assert tool_names == {"add", "multiply", "get_weather"}
+
+        await client.disconnect_server("math")
+
+        # Check that we have only tools from weather server
+        all_tools = client.get_tools()
+        assert len(all_tools) == 1
+
+        await client.disconnect_server("weather")
+
+        # Check that we have no tool now
+        all_tools = client.get_tools()
+        assert len(all_tools) == 0
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds support for disconnecting a single server and releasing allocated resources.

Adds a disconnect_server function taking a server_name as parameter.

Also replaces the existing single exit_stack with a dict to have a single exit_stack for each server