### PR TITLE
add support for converting MCP types (images, pdfs. etc) to langchain tool artifacts

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -11,10 +11,41 @@ from mcp.types import (
 from mcp.types import (
     Tool as MCPTool,
 )
+from pydantic.networks import AnyUrl
 
 NonTextContent = ImageContent | EmbeddedResource
 
-
+def _convert_mcp_artifact_types_to_langchain(non_text_content):
+    if isinstance(non_text_content, ImageContent):
+        return {
+            "type": "image_url",
+            "image_url": {"url": non_text_content.data},
+        }
+    elif isinstance(non_text_content, EmbeddedResource):
+        if hasattr(non_text_content, 'resource'):
+            artifact_resource = non_text_content.resource
+            if hasattr(artifact_resource, 'blob'):
+                artifact_name = artifact_resource.blob
+            else:
+                raise Exception("No blob found in the artifact")
+            if hasattr(artifact_resource, 'uri'):
+                artifact_uri = artifact_resource.uri
+                if isinstance(artifact_uri, AnyUrl):
+                    if artifact_uri.scheme:
+                        file_data = artifact_uri.scheme + ":" + artifact_uri.path
+                    else:
+                        file_data = artifact_uri.path
+                else:
+                    raise Exception("No uri found in the artifact")
+            else:
+                raise Exception("No uri found in the artifact")
+            return {
+                "type": "file",
+                "file": {"filename": artifact_name, "file_data": file_data},
+            }
+    else:
+        raise NotImplementedError("Artifact type not supported")
+    
 def _convert_call_tool_result(
     call_tool_result: CallToolResult,
 ) -> tuple[str | list[str], list[NonTextContent] | None]:
@@ -24,7 +55,7 @@ def _convert_call_tool_result(
         if isinstance(content, TextContent):
             text_contents.append(content)
         else:
-            non_text_contents.append(content)
+            non_text_contents.append(_convert_mcp_artifact_types_to_langchain(content))
 
     tool_content: str | list[str] = [content.text for content in text_contents]
     if len(text_contents) == 1:


### PR DESCRIPTION
# Add support for converting MCP types (images, pdfs. etc) to langchain tool artifacts

Currently langchain can't handle MCP tools that return ImageContent or PDF, cuz the artifact is sent back as the MCP type class, not the expected input of the LLM APIs.

This PR converts the tool output for non text content to the expected LLM format
