### PR TITLE
fix: handle empty tool response

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -27,7 +27,9 @@ def _convert_call_tool_result(
             non_text_contents.append(content)
 
     tool_content: str | list[str] = [content.text for content in text_contents]
-    if len(text_contents) == 1:
+    if not text_contents:
+        tool_content = ""
+    elif len(text_contents) == 1:
         tool_content = tool_content[0]
 
     if call_tool_result.isError:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -19,6 +19,19 @@ from langchain_mcp_adapters.tools import (
 )
 
 
+def test_convert_empty_text_content():
+    # Test with a single text content
+    result = CallToolResult(
+        content=[],
+        isError=False,
+    )
+
+    text_content, non_text_content = _convert_call_tool_result(result)
+
+    assert text_content == ""
+    assert non_text_content is None
+
+
 def test_convert_single_text_content():
     # Test with a single text content
     result = CallToolResult(


### PR DESCRIPTION
Convert and empty response to an empty string.

I have a tool that returns an empty response which eventually fails on [this line](https://github.com/langchain-ai/langchain-google/blob/d8c860f4b7970a8c701479aff7e7deec264b7e86/libs/vertexai/langchain_google_vertexai/chat_models.py#L451) because the list is empty.

This change fixes the problem and seems valid considering how the conversion for a single message converts the response to a string as well.