### PR TITLE
feat: add cwd option to StdioServerParameters

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -186,6 +186,7 @@ class MultiServerMCPClient:
                 command=kwargs["command"],
                 args=kwargs["args"],
                 env=kwargs.get("env"),
+                cwd=kwargs.get("cwd"),
                 encoding=kwargs.get("encoding", DEFAULT_ENCODING),
                 encoding_error_handler=kwargs.get(
                     "encoding_error_handler", DEFAULT_ENCODING_ERROR_HANDLER
@@ -210,6 +211,7 @@ class MultiServerMCPClient:
         command: str,
         args: list[str],
         env: dict[str, str] | None = None,
+        cwd: str | Path | None = None,
         encoding: str = DEFAULT_ENCODING,
         encoding_error_handler: Literal[
             "strict", "ignore", "replace"
@@ -223,6 +225,7 @@ class MultiServerMCPClient:
             command: Command to execute
             args: Arguments for the command
             env: Environment variables for the command
+            cwd: Working directory for the command
             encoding: Character encoding
             encoding_error_handler: How to handle encoding errors
             session_kwargs: Additional keyword arguments to pass to the ClientSession
@@ -240,6 +243,7 @@ class MultiServerMCPClient:
             env=env,
             encoding=encoding,
             encoding_error_handler=encoding_error_handler,
+            cwd=cwd
         )
 
         # Create and store the connection

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -241,9 +241,9 @@ class MultiServerMCPClient:
             command=command,
             args=args,
             env=env,
+            cwd=cwd,
             encoding=encoding,
             encoding_error_handler=encoding_error_handler,
-            cwd=cwd
         )
 
         # Create and store the connection


### PR DESCRIPTION
Hello,

I've been making good use of the langchain-mcp-adapters, 
and I wanted to address an issue I've encountered. 
It seems that the option to set the working directory (cwd) for the spawned process, 
when running MCP using standard I/O is missing. 

In my current setup, I have two repositories: 
- repository A with a langraph agent 
- and repository B containing MCP tools. 

Both repositories have folders with identical names, causing issues for the spawned process in correctly importing modules from repository B. 
Although the official MCP repository includes this option, it appears to be absent here, so I'm submitting this pull request.

https://github.com/modelcontextprotocol/python-sdk/blob/3b1b213a9669579ba04b3552e404f90a39baf8eb/src/mcp/client/stdio/__init__.py#L77-L78

This is a simple change, so I'm submitting it without test code for now. 
Please let me know if you have any feedback, and I'll be happy to make further improvements.

Thank you!