### PR TITLE
Add ValueError for missing transport key: sessions.py

### DIFF
--- a/langchain_mcp_adapters/sessions.py
+++ b/langchain_mcp_adapters/sessions.py
@@ -247,6 +247,15 @@ async def create_session(
     Yields:
         A ClientSession
     """
+
+    if "transport" not in connection:
+        raise ValueError(
+            "Configuration error: Missing 'transport' key in server configuration. "
+            "Each server must include 'transport' with one of: 'stdio', 'sse', 'websocket', 'streamable_http'. "
+            f"Received: {connection}. "
+            "Refer to the documentation: https://github.com/langchain-ai/langchain-mcp-adapters?tab=readme-ov-file#client-1"
+        )
+        
     transport = connection["transport"]
     if transport == "sse":
         if "url" not in connection:


### PR DESCRIPTION
This pull request adds a `ValueError` to validate missing `transport` keys in `MultiServerMCPClient` server configurations. The error message includes valid `transport` values (`stdio`, `sse`, `websocket`, `streamable_http`) and a link to the documentation for clarity.

The change was prompted by Grok and ChatGPT suggesting an invalid configuration, such as:


```
{
  "mcpServers": {
    "gitmcp": {
      "command": "npx",
      "args": ["mcp-remote", "https://gitmcp.io/{owner}/{repo}"]
    }
  }
}
```

This caused a `KeyError: transport` due to incorrect nesting and missing `transport`. A warning was added to guide users to the correct top-level format, improving error clarity and preventing similar issues.