### PR TITLE
docs: When using streamable_http, the mcp-url must end with a slash. On cloud servers we get the following error

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ client = MultiServerMCPClient(
         },
         "weather": {
             # make sure you start your weather server on port 8000
-            "url": "http://localhost:8000/mcp",
+            "url": "http://localhost:8000/mcp/",
             "transport": "streamable_http",
         }
     }
@@ -169,7 +169,7 @@ from mcp.client.streamable_http import streamablehttp_client
 from langgraph.prebuilt import create_react_agent
 from langchain_mcp_adapters.tools import load_mcp_tools
 
-async with streamablehttp_client("http://localhost:3000/mcp") as (read, write, _):
+async with streamablehttp_client("http://localhost:3000/mcp/") as (read, write, _):
     async with ClientSession(read, write) as session:
         # Initialize the connection
         await session.initialize()
@@ -191,7 +191,7 @@ client = MultiServerMCPClient(
     {
         "math": {
             "transport": "streamable_http",
-            "url": "http://localhost:3000/mcp"
+            "url": "http://localhost:3000/mcp/"
         },
     }
 )
@@ -220,7 +220,7 @@ client = MultiServerMCPClient(
         },
         "weather": {
             # make sure you start your weather server on port 8000
-            "url": "http://localhost:8000/mcp",
+            "url": "http://localhost:8000/mcp/",
             "transport": "streamable_http",
         }
     }
@@ -269,7 +269,7 @@ async def make_graph():
             },
             "weather": {
                 # make sure you start your weather server on port 8000
-                "url": "http://localhost:8000/mcp",
+                "url": "http://localhost:8000/mcp/",
                 "transport": "streamable_http",
             }
         }


### PR DESCRIPTION
## 📝 Summary of Commit
Fix README: Add trailing slashes to `streamable_http` URLs to prevent 307 redirects.  
When using the `streamable_http` adapter, the `mcp-url` must end with a trailing slash (`/`).  
Without it, requests to cloud-based deployments can return a `307 Temporary Redirect` error.

This PR updates the `README.md` to reflect the correct usage by adding trailing slashes to the `mcp-url` values in all `streamable_http` examples.

## ❗ Before
```bash
--mcp-url http://localhost:8000/mcp
```

## ✅ After
```bash
--mcp-url http://localhost:8000/mcp/
```

## 📚 Why this matters
In production environments (e.g., behind load balancers or cloud services),  
the missing slash causes an unnecessary redirect which can break `POST` requests.  
Adding the slash avoids this issue.

## ✅ Tested

Verified in a cloud environment where the redirect caused failed requests when the trailing slash was missing. (eg: `Digitalocean`) I created two app-platform : `langchain-mcp-client` and `fastmcp-mcp-server`

---

Let me know if you'd like me to update other docs or examples as well.