### PR TITLE
feat: enhance load_mcp_tools to support loading specific tool IDs

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -118,8 +118,14 @@ async def load_mcp_tools(
     session: ClientSession | None,
     *,
     connection: Connection | None = None,
+    tool_ids: list[str] | None = None,
 ) -> list[BaseTool]:
-    """Load all available MCP tools and convert them to LangChain tools.
+    """Load selected or all MCP tools and convert them to LangChain tools.
+
+    Args:
+        session: MCP client session
+        connection: Optional connection config to use to create a new session if a `session` is not provided
+        tool_ids: List of specific tool names/ids to load. If empty or None, load all tools.
 
     Returns:
         list of LangChain tools. Tool annotations are returned as part
@@ -135,6 +141,10 @@ async def load_mcp_tools(
             tools = await _list_all_tools(tool_session)
     else:
         tools = await _list_all_tools(session)
+
+    # If tool_ids is provided and not empty, filter tools by name
+    if tool_ids:
+        tools = [tool for tool in tools if tool.name in tool_ids]
 
     converted_tools = [
         convert_mcp_tool_to_langchain_tool(session, tool, connection=connection) for tool in tools

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -446,3 +446,49 @@ async def test_load_mcp_tools_with_custom_httpx_client_factory_sse(
             # Expected to fail since server doesn't have SSE endpoint,
             # but the important thing is that httpx_client_factory was passed correctly
             pass
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_tools_with_no_tool_ids():
+    tool_input_schema = {
+        "properties": {
+            "param1": {"title": "Param1", "type": "string"},
+            "param2": {"title": "Param2", "type": "integer"},
+        },
+        "required": ["param1", "param2"],
+        "title": "ToolSchema",
+        "type": "object",
+    }
+    session = AsyncMock()
+    mcp_tools = [
+        MCPTool(name="tool1", description="Tool 1", inputSchema=tool_input_schema),
+        MCPTool(name="tool2", description="Tool 2", inputSchema=tool_input_schema),
+        MCPTool(name="tool3", description="Tool 3", inputSchema=tool_input_schema),
+    ]
+    session.list_tools.return_value = MagicMock(tools=mcp_tools, nextCursor=None)
+    tools = await load_mcp_tools(session)
+    assert len(tools) == 3
+    assert {t.name for t in tools} == {"tool1", "tool2", "tool3"}
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_tools_with_specific_tool_ids():
+    tool_input_schema = {
+        "properties": {
+            "param1": {"title": "Param1", "type": "string"},
+            "param2": {"title": "Param2", "type": "integer"},
+        },
+        "required": ["param1", "param2"],
+        "title": "ToolSchema",
+        "type": "object",
+    }
+    session = AsyncMock()
+    mcp_tools = [
+        MCPTool(name="tool1", description="Tool 1", inputSchema=tool_input_schema),
+        MCPTool(name="tool2", description="Tool 2", inputSchema=tool_input_schema),
+        MCPTool(name="tool3", description="Tool 3", inputSchema=tool_input_schema),
+    ]
+    session.list_tools.return_value = MagicMock(tools=mcp_tools, nextCursor=None)
+    tools = await load_mcp_tools(session, tool_ids=["tool1", "tool3"])
+    assert len(tools) == 2
+    assert {t.name for t in tools} == {"tool1", "tool3"}


### PR DESCRIPTION
## Summary 
This PR updates the `load_mcp_tools` function in [tools.py](langchain_mcp_adapters/tools.py) to support loading a specific subset of tools by their IDs. It also adds new unit tests to verify this behavior.

## Details
### Feature:

The `load_mcp_tools` function now accepts an optional `tool_ids` argument (a list of string tool names/IDs).
If `tool_ids` is provided and not empty, only tools with matching names are loaded.
If `tool_ids` is empty or not provided, all available tools are loaded (existing behavior).

### Tests:

Added `test_load_mcp_tools_with_no_tool_ids` to verify that all tools are loaded when no IDs are specified.
Added `test_load_mcp_tools_with_specific_tool_ids` to verify that only the specified tools are loaded when IDs are provided.

### Motivation
This change allows users to selectively load only the tools they need, improving efficiency and flexibility when working with large sets of MCP tools.

## Additional Notes
All new and existing tests pass with the updated implementation.