### PR TITLE
fix: pagination nextCursor is empty strings

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -55,7 +55,9 @@ async def _list_all_tools(session: ClientSession) -> list[MCPTool]:
         if list_tools_page_result.tools:
             all_tools.extend(list_tools_page_result.tools)
 
-        if list_tools_page_result.nextCursor is None:
+        # Pagination spec: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/pagination
+        # compatible with None or ""
+        if not list_tools_page_result.nextCursor:
             break
 
         current_cursor = list_tools_page_result.nextCursor


### PR DESCRIPTION
Pagination spec: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/pagination
Pagination nextCurour compatible with None or empty strings.

Prevent reaching MAX_ITERATIONS, some third-party MCP service implementations​. nextCursor is empty strings.

e.g., higress:

https://github.com/alibaba/higress/blob/main/plugins/golang-filter/mcp-session/common/server.go#L624-L627
