### PR TITLE
[Feature] Add Support for `handle_tool_error` and `handle_validation_error` in `load_mcp_tools`

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -37,7 +37,7 @@ from mcp.types import (
     TextResourceContents,
 )
 from mcp.types import Tool as MCPTool
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel, ValidationError, create_model
 
 from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks, _MCPCallbacks
 from langchain_mcp_adapters.interceptors import (
@@ -278,6 +278,10 @@ def convert_mcp_tool_to_langchain_tool(
     tool_interceptors: list[ToolCallInterceptor] | None = None,
     server_name: str | None = None,
     tool_name_prefix: bool = False,
+    handle_tool_error: bool | str | Callable[[ToolException], str] | None = False,
+    handle_validation_error: (
+        bool | str | Callable[[ValidationError], str] | None
+    ) = False,
 ) -> BaseTool:
     """Convert an MCP tool to a LangChain tool.
 
@@ -293,6 +297,8 @@ def convert_mcp_tool_to_langchain_tool(
         server_name: Name of the server this tool belongs to
         tool_name_prefix: If `True` and `server_name` is provided, the tool name will be
             prefixed w/ server name (e.g., `"weather_search"` instead of `"search"`)
+        handle_tool_error: Optional error handler for tool execution errors.
+        handle_validation_error: Optional error handler for validation errors.
 
     Returns:
         a LangChain tool
@@ -430,6 +436,8 @@ def convert_mcp_tool_to_langchain_tool(
         coroutine=call_tool,
         response_format="content_and_artifact",
         metadata=metadata,
+        handle_tool_error=handle_tool_error,
+        handle_validation_error=handle_validation_error,
     )
 
 
@@ -441,6 +449,10 @@ async def load_mcp_tools(
     tool_interceptors: list[ToolCallInterceptor] | None = None,
     server_name: str | None = None,
     tool_name_prefix: bool = False,
+    handle_tool_error: bool | str | Callable[[ToolException], str] | None = False,
+    handle_validation_error: (
+        bool | str | Callable[[ValidationError], str] | None
+    ) = False,
 ) -> list[BaseTool]:
     """Load all available MCP tools and convert them to LangChain [tools](https://docs.langchain.com/oss/python/langchain/tools).
 
@@ -452,6 +464,8 @@ async def load_mcp_tools(
         server_name: Name of the server these tools belong to.
         tool_name_prefix: If `True` and `server_name` is provided, tool names will be
             prefixed w/ server name (e.g., `"weather_search"` instead of `"search"`).
+        handle_tool_error: Optional error handler for tool execution errors.
+        handle_validation_error: Optional error handler for validation errors.
 
     Returns:
         List of LangChain [tools](https://docs.langchain.com/oss/python/langchain/tools).
@@ -492,6 +506,8 @@ async def load_mcp_tools(
             tool_interceptors=tool_interceptors,
             server_name=server_name,
             tool_name_prefix=tool_name_prefix,
+            handle_tool_error=handle_tool_error,
+            handle_validation_error=handle_validation_error,
         )
         for tool in tools
     ]


### PR DESCRIPTION
Fixes: #263

## Summary
This PR enhances the `load_mcp_tools` function to accept two new optional parameters:
- `handle_tool_error`
- `handle_validation_error`

These parameters are forwarded to the `StructuredTool` constructor for each tool, allowing users to customize how errors and validation issues are handled.

## Changes Made
- Updated the `load_mcp_tools` signature to accept `handle_tool_error` and `handle_validation_error`.
- Passed these parameters when instantiating each `StructuredTool`.

### Example Usage
```python
tools = load_mcp_tools(
    ...,
    handle_tool_error=custom_tool_error_handler,
    handle_validation_error=custom_validation_handler
)
```

This change is fully backward-compatible and does not affect existing behavior if the new parameters are not provided.
