### PR TITLE
Allow passing streamable-http and http as transport

### DIFF
--- a/langchain_mcp_adapters/sessions.py
+++ b/langchain_mcp_adapters/sessions.py
@@ -383,7 +383,7 @@ async def create_session(connection: Connection) -> AsyncIterator[ClientSession]
             raise ValueError(msg)
         async with _create_sse_session(**params) as session:
             yield session
-    elif transport == "streamable_http":
+    elif transport in {"streamable_http", "streamable-http", "http"}:
         if "url" not in params:
             msg = "'url' parameter is required for Streamable HTTP connection"
             raise ValueError(msg)


### PR DESCRIPTION
These names are preferred by servers written in FastMCP >= 2.3.0 https://gofastmcp.com/deployment/running-server#streamable-http

They are fully supported aliases according to documentation.

Fix #267