### PR TITLE
feat: Add MCP structuredContent support (fixes #283)

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -527,18 +527,18 @@ async def test_convert_mcp_tool_metadata_variants():
         "_meta": {"flag": True},
     }
 
+
 def test_convert_with_structured_content():
     """Test CallToolResult with structuredContent field."""
     structured_data = {"results": [{"id": 1}, {"id": 2}], "count": 2}
-    
+
     result = CallToolResult(
-        content=[TextContent(type="text", text="Search completed")],
-        isError=False
+        content=[TextContent(type="text", text="Search completed")], isError=False
     )
     result.structuredContent = structured_data
-    
+
     text_content, artifact = _convert_call_tool_result(result)
-    
+
     assert text_content == "Search completed"
     assert artifact["structuredContent"] == structured_data
 
@@ -546,15 +546,14 @@ def test_convert_with_structured_content():
 def test_convert_structured_content_includes_json_block():
     """Test that structuredContent is included in artifact only."""
     structured_data = {"result": "success"}
-    
+
     result = CallToolResult(
-        content=[TextContent(type="text", text="Done")],
-        isError=False
+        content=[TextContent(type="text", text="Done")], isError=False
     )
     result.structuredContent = structured_data
-    
+
     content, artifact = _convert_call_tool_result(result)
-    
+
     # Content stays simple - just the text
     assert content == "Done"
     # Structured data goes in artifact
@@ -564,11 +563,11 @@ def test_convert_structured_content_includes_json_block():
 def test_convert_with_structured_content_only():
     """Test CallToolResult with only structuredContent, no text content."""
     structured_data = {"status": "success"}
-    
+
     result = CallToolResult(content=[], isError=False)
     result.structuredContent = structured_data
-    
+
     content, artifact = _convert_call_tool_result(result)
-    
+
     assert content == ""
     assert artifact["structuredContent"] == structured_data


### PR DESCRIPTION
Implement MCP structuredContent support to resolve data loss issue

This branch addresses Issue #283 by implementing proper support for MCP's 
structuredContent field in CallToolResult responses. Previously, the 
langchain-mcp-adapters library ignored the structuredContent 
field.

Key Changes:
• Refactored _convert_call_tool_result() to handle structuredContent
• Updated return format to use LangChain's content_and_artifact pattern

The implementation ensures:
- structuredContent is preserved in artifact["structuredContent"] 
- Backward compatibility with existing text/non-text content handling
- Compliance with MCP specification (2025-06-18)


Example:
```python
from langchain_core.messages import ToolCall
result = await tool.ainvoke(
    ToolCall(
        name="tool_name",
        args={....},
        id="call_123",  # any unique string ID
        type="tool_call",
    )
    
)
print(result.content)
if result.artifact:
    print(result.artifact.get("structuredContent", None))
    print(result.artifact.get("nonText", None))
```

Fixes: #283