### PR TITLE
add StreamableHttpConnectionWithSigV4

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -24,6 +24,7 @@ from langchain_mcp_adapters.sessions import (
     StdioConnection,
     StreamableHttpConnection,
     WebsocketConnection,
+    StreamableHttpConnectionWithSigV4,
     create_session,
 )
 from langchain_mcp_adapters.tools import load_mcp_tools
@@ -223,5 +224,6 @@ __all__ = [
     "SSEConnection",
     "StdioConnection",
     "StreamableHttpConnection",
+    "StreamableHttpConnectionWithSigV4",
     "WebsocketConnection",
 ]

--- a/langchain_mcp_adapters/streamable_http_sigv4.py
+++ b/langchain_mcp_adapters/streamable_http_sigv4.py
@@ -1,0 +1,155 @@
+"""
+StreamableHTTP Client Transport with AWS SigV4 Signing
+
+This module extends the MCP StreamableHTTPTransport to add AWS SigV4 request signing
+for authentication with MCP servers that authenticate using AWS IAM.
+"""
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from typing import Generator
+
+import httpx
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+from mcp.client.streamable_http import (
+    GetSessionIdCallback,
+    StreamableHTTPTransport,
+    streamablehttp_client,
+)
+from mcp.shared._httpx_utils import McpHttpClientFactory, create_mcp_http_client
+from mcp.shared.message import SessionMessage
+
+
+class SigV4HTTPXAuth(httpx.Auth):
+    """HTTPX Auth class that signs requests with AWS SigV4."""
+
+    def __init__(
+        self,
+        credentials: Credentials,
+        service: str,
+        region: str,
+    ):
+        self.credentials = credentials
+        self.service = service
+        self.region = region
+        self.signer = SigV4Auth(credentials, service, region)
+
+    def auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """Signs the request with SigV4 and adds the signature to the request headers."""
+
+        # Create an AWS request
+        headers = dict(request.headers)
+        # Header 'connection' = 'keep-alive' is not used in calculating the request
+        # signature on the server-side, and results in a signature mismatch if included
+        headers.pop("connection", None)  # Remove if present, ignore if not
+
+        aws_request = AWSRequest(
+            method=request.method,
+            url=str(request.url),
+            data=request.content,
+            headers=headers,
+        )
+
+        # Sign the request with SigV4
+        self.signer.add_auth(aws_request)
+
+        # Add the signature header to the original request
+        request.headers.update(dict(aws_request.headers))
+
+        yield request
+
+
+class StreamableHTTPTransportWithSigV4(StreamableHTTPTransport):
+    """
+    Streamable HTTP client transport with AWS SigV4 signing support.
+
+    This transport enables communication with MCP servers that authenticate using AWS IAM,
+    such as servers behind a Lambda function URL or API Gateway.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        credentials: Credentials,
+        service: str,
+        region: str,
+        headers: dict[str, str] | None = None,
+        timeout: float | timedelta = 30,
+        sse_read_timeout: float | timedelta = 60 * 5,
+    ) -> None:
+        """Initialize the StreamableHTTP transport with SigV4 signing.
+
+        Args:
+            url: The endpoint URL.
+            credentials: AWS credentials for signing.
+            service: AWS service name (e.g., 'lambda').
+            region: AWS region (e.g., 'us-east-1').
+            headers: Optional headers to include in requests.
+            timeout: HTTP timeout for regular operations.
+            sse_read_timeout: Timeout for SSE read operations.
+        """
+        # Initialize parent class with SigV4 auth handler
+        super().__init__(
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            sse_read_timeout=sse_read_timeout,
+            auth=SigV4HTTPXAuth(credentials, service, region),
+        )
+
+        self.credentials = credentials
+        self.service = service
+        self.region = region
+
+
+@asynccontextmanager
+async def streamablehttp_client_with_sigv4(
+    url: str,
+    credentials: Credentials,
+    service: str,
+    region: str,
+    headers: dict[str, str] | None = None,
+    timeout: float | timedelta = 30,
+    sse_read_timeout: float | timedelta = 60 * 5,
+    terminate_on_close: bool = True,
+    httpx_client_factory: McpHttpClientFactory | None = None,
+) -> AsyncGenerator[
+    tuple[
+        MemoryObjectReceiveStream[SessionMessage | Exception],
+        MemoryObjectSendStream[SessionMessage],
+        GetSessionIdCallback,
+    ],
+    None,
+]:
+    """
+    Client transport for Streamable HTTP with SigV4 auth.
+
+    This transport enables communication with MCP servers that authenticate using AWS IAM,
+    such as servers behind a Lambda function URL or API Gateway.
+
+    Yields:
+        Tuple containing:
+            - read_stream: Stream for reading messages from the server
+            - write_stream: Stream for sending messages to the server
+            - get_session_id_callback: Function to retrieve the current session ID
+    """
+    kwargs = {}
+    if httpx_client_factory is not None:
+        kwargs["httpx_client_factory"] = httpx_client_factory
+
+    async with streamablehttp_client(
+        url=url,
+        headers=headers,
+        timeout=timeout,
+        sse_read_timeout=sse_read_timeout,
+        terminate_on_close=terminate_on_close,
+        auth=SigV4HTTPXAuth(credentials, service, region),
+        **kwargs,
+    ) as result:
+        yield result

--- a/tests/test_streamable_http_sigv4.py
+++ b/tests/test_streamable_http_sigv4.py
@@ -1,0 +1,38 @@
+"""Essential tests for streamable HTTP with SigV4 authentication."""
+
+from unittest.mock import Mock, patch
+from botocore.credentials import Credentials
+
+from langchain_mcp_adapters.streamable_http_sigv4 import SigV4HTTPXAuth
+
+
+def test_sigv4_auth_initialization():
+    """Test SigV4HTTPXAuth initializes with correct credentials and region."""
+    credentials = Credentials(access_key="test_key", secret_key="test_secret")
+
+    auth = SigV4HTTPXAuth(credentials, "bedrock-agentcore", "us-east-1")
+
+    assert auth.credentials == credentials
+    assert auth.service == "bedrock-agentcore"
+    assert auth.region == "us-east-1"
+
+
+def test_auth_flow_removes_connection_header():
+    """Test that connection header is removed during SigV4 signing."""
+    credentials = Credentials(access_key="test_key", secret_key="test_secret")
+    auth = SigV4HTTPXAuth(credentials, "bedrock-agentcore", "us-east-1")
+
+    request = Mock()
+    request.method = "POST"
+    request.url = "https://example.com/api"
+    request.content = b"{}"
+    request.headers = {"connection": "keep-alive", "content-type": "application/json"}
+
+    with patch.object(auth.signer, "add_auth"):
+        with patch("botocore.awsrequest.AWSRequest") as mock_aws_request:
+            list(auth.auth_flow(request))
+
+            # Verify connection header was removed from AWS request
+            call_args = mock_aws_request.call_args[1]
+            assert "connection" not in call_args["headers"]
+            assert "content-type" in call_args["headers"]


### PR DESCRIPTION
Fix #292

Here is the my test.


```python
import asyncio
from langchain_mcp_adapters.client import MultiServerMCPClient
from langgraph.prebuilt import create_react_agent
from dotenv import load_dotenv

load_dotenv()

region = "us-west-2"
account_id = "xxx"
agent_name = "mcp_server_agentcore-0ZBA39505B"

user_prompt = "Use the list_log_groups tool to get exactly 5 log group names. Call the tool now and return the actual log group names from the results."

agent_arn = f"arn:aws:bedrock-agentcore:{region}:{account_id}:runtime/{agent_name}"
encoded_arn = agent_arn.replace(':', '%3A').replace('/', '%2F')
mcp_url = f"https://bedrock-agentcore.{region}.amazonaws.com/runtimes/{encoded_arn}/invocations?qualifier=DEFAULT"

client = MultiServerMCPClient(
    {
        "cloudwatch": {
            "transport": "streamable_http",
            "url": mcp_url,
            "region": region
        },
    }
)

async def main():
    print("Loading MCP tools...")
    try:
        tools = await client.get_tools()
        print(f"✅ Successfully loaded {len(tools)} tools:")
        for tool in tools:
            print(f"  - {tool.name}: {tool.description}")
        
        # First, let's test the tool directly to prove our MCP implementation works
        print(f"\n🧪 Testing tool directly (bypassing agent)...")
        list_log_groups_tool = next((tool for tool in tools if tool.name == "list_log_groups"), None)
        if list_log_groups_tool is None:
            print("❌ Could not find list_log_groups tool")
            return
        direct_result = await list_log_groups_tool.ainvoke({"limit": 5})
        print(f"✅ Direct tool call result: {direct_result}")
        
        print(f"\n🤖 Now testing with LangChain agent...")
        agent = create_react_agent("openai:gpt-4o-mini", tools)
        print(f"✅ Agent created: {agent}")
        response = await agent.ainvoke({
            "messages": user_prompt
        })
        print("✅ Agent response:", response)
        
    except Exception as e:
        print(f"❌ Error: {e}")
        import traceback
        traceback.print_exc()

if __name__ == "__main__":
    asyncio.run(main())

```

```output
Loading MCP tools...
Connections: {'cloudwatch': {'transport': 'streamable_http', 'url': 'https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-west-2%3Axxx%3Aruntime%2Fmcp_server_agentcore-0ZBA39505B/invocations?qualifier=DEFAULT', 'region': 'us-west-2'}}
Session termination failed: 404
✅ Successfully loaded 7 tools:
  - list_log_groups: 
    List available CloudWatch log groups with optional filtering by prefix.

    Args:
        prefix: Optional prefix to filter log groups by name
        limit: Maximum number of log groups to return (default: 50)
        next_token: Token for pagination to get the next set of results
        profile: Optional AWS profile name to use for credentials
        region: Optional AWS region name to use for API calls
        role_arn: Optional ARN of the role to assume in another AWS account
        external_id: Optional external ID for cross-account role assumption

    Returns:
        JSON string with log groups information
    
  - search_logs: 
    Search logs using CloudWatch Logs Insights query.

    Args:
        log_group_name: The log group to search
        query: CloudWatch Logs Insights query syntax
        hours: Number of hours to look back
        start_time: Optional ISO8601 start time
        end_time: Optional ISO8601 end time
        profile: Optional AWS profile name to use for credentials
        region: Optional AWS region name to use for API calls
        role_arn: Optional ARN of the role to assume in another AWS account
        external_id: Optional external ID for cross-account role assumption

    Returns:
        JSON string with search results
    
  - search_logs_multi: 
    Search logs across multiple log groups using CloudWatch Logs Insights.

    Args:
        log_group_names: List of log groups to search
        query: CloudWatch Logs Insights query in Logs Insights syntax
        hours: Number of hours to look back (default: 24)
        start_time: Optional ISO8601 start time
        end_time: Optional ISO8601 end time
        profile: Optional AWS profile name to use for credentials
        region: Optional AWS region name to use for API calls

    Returns:
        JSON string with search results
    
  - filter_log_events: 
    Filter log events by pattern across all streams in a log group.

    Args:
        log_group_name: The log group to filter
        filter_pattern: The pattern to search for (CloudWatch Logs filter syntax)
        hours: Number of hours to look back
        start_time: Optional ISO8601 start time
        end_time: Optional ISO8601 end time
        profile: Optional AWS profile name to use for credentials
        region: Optional AWS region name to use for API calls

    Returns:
        JSON string with filtered events
    
  - summarize_log_activity: 
    Generate a summary of log activity over a specified time period.

    Args:
        log_group_name: The log group to analyze
        hours: Number of hours to look back
        start_time: Optional ISO8601 start time
        end_time: Optional ISO8601 end time
        profile: Optional AWS profile name to use for credentials
        region: Optional AWS region name to use for API calls

    Returns:
        JSON string with activity summary
    
  - find_error_patterns: 
    Find common error patterns in logs.

    Args:
        log_group_name: The log group to analyze
        hours: Number of hours to look back
        start_time: Optional ISO8601 start time
        end_time: Optional ISO8601 end time
        profile: Optional AWS profile name to use for credentials
        region: Optional AWS region name to use for API calls

    Returns:
        JSON string with error patterns
    
  - correlate_logs: 
    Correlate logs across multiple AWS services using a common search term.

    Args:
        log_group_names: List of log group names to search
        search_term: Term to search for in logs (request ID, transaction ID, etc.)
        hours: Number of hours to look back
        start_time: Optional ISO8601 start time
        end_time: Optional ISO8601 end time
        profile: Optional AWS profile name to use for credentials
        region: Optional AWS region name to use for API calls

    Returns:
        JSON string with correlated events
    

🧪 Testing tool directly (bypassing agent)...
Session termination failed: 404
✅ Direct tool call result: {
  "logGroups": [
    {
      "name": "/aws/apigateway/welcome",
      "arn": "arn:aws:logs:us-east-1:xxx:log-group:/aws/apigateway/welcome:*",
      "storedBytes": 6741,
      "creationTime": "2022-04-12T08:11:23.996000"
    },
...
  "nextToken": "/aws/cognito/userpools/xxx"
}

🤖 Now testing with LangChain agent...
✅ Agent created: <langgraph.graph.state.CompiledStateGraph object at 0x11349b680>
Session termination failed: 404
✅ Agent response: {'messages': [HumanMessage(content='Use the list_log_groups tool to get exactly 5 log group names. Call the tool now and return the actual log group names from the results.', additional_kwargs={}, response_metadata={}, id='7befeeb7-9be8-4ab0-ab87-e2a75661b8d2'), xxx}
```


@mdrxy Could you help review it?

Feel free to let me know if you have any concerns.

Reference:
https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-oauth.html

https://github.com/awslabs/run-model-context-protocol-servers-with-aws-lambda/blob/main/src/python/src/mcp_lambda/client/streamable_http_sigv4.py
