### PR TITLE
mcp[patch]: raise a runtime error if the tool call is not available

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -139,7 +139,7 @@ def convert_mcp_tool_to_langchain_tool(
         if call_tool_result is None:
             raise RuntimeError(
                 "The tool call did not return any content. This **may** have "
-                "happened due to a network error, a closed connection."
+                "happened due to a network error, a timeout, a closed connection etc"
             )
 
         return _convert_call_tool_result(call_tool_result)

--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -138,8 +138,10 @@ def convert_mcp_tool_to_langchain_tool(
 
         if call_tool_result is None:
             raise RuntimeError(
-                "The tool call did not return any content. This **may** have "
-                "happened due to a network error, a timeout, a closed connection etc"
+                "Tool call failed: no result returned from the underlying MCP SDK. "
+                "This may indicate that an exception was handled or suppressed "
+                "by the MCP SDK (e.g., client disconnection, network issue, "
+                "or other execution error)."
             )
 
         return _convert_call_tool_result(call_tool_result)

--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -124,6 +124,7 @@ def convert_mcp_tool_to_langchain_tool(
     async def call_tool(
         **arguments: dict[str, Any],
     ) -> tuple[str | list[str], list[NonTextContent] | None]:
+        call_tool_result = None
         if session is None:
             # If a session is not provided, we will create one on the fly
             async with create_session(connection) as tool_session:
@@ -134,6 +135,13 @@ def convert_mcp_tool_to_langchain_tool(
                 )
         else:
             call_tool_result = await session.call_tool(tool.name, arguments)
+
+        if call_tool_result is None:
+            raise RuntimeError(
+                "The tool call did not return any content. This **may** have "
+                "happened due to a network error, a closed connection."
+            )
+
         return _convert_call_tool_result(call_tool_result)
 
     meta = tool.meta if hasattr(tool, "meta") else None


### PR DESCRIPTION
mcp-sdk context manager is swallowing some classes of exceptions with no way to recover the actual error the occurred. 

This patch makes a slight improvement to the exception an end user sees (so it's not an unbound variable). 

Unfortunately, we don't have any information about the root cause (we don't even know whether a timeout can cause this.)

I'll try to recreate this issue: https://github.com/langchain-ai/langchain-mcp-adapters/issues/314 in unit tests to see if we can trigger it with timeouts.