### PR TITLE
fix: add repository URL section to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = [
     { name = "Vadym Barda", email = "19161700+vbarda@users.noreply.github.com" },
 ]
 license = "MIT"
-repository = "https://www.github.com/langchain-ai/langchain-mcp-adapters"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
@@ -30,6 +29,9 @@ test = [
     "websockets>=15.0.1",
     "pytest-timeout>=2.4.0",
 ]
+
+[project.urls]
+repository = "https://www.github.com/langchain-ai/langchain-mcp-adapters"
 
 [tool.pytest.ini_options]
 minversion = "8.0"


### PR DESCRIPTION
wasn't linking in PyPi