### PR TITLE
feat: list and read resources as tools

### DIFF
--- a/langchain_mcp_adapters/resources.py
+++ b/langchain_mcp_adapters/resources.py
@@ -12,7 +12,7 @@ from langchain_core.tools import BaseTool, StructuredTool
 from mcp import ClientSession
 from mcp.types import BlobResourceContents, ResourceContents, TextResourceContents
 from pydantic import BaseModel, Field
-from langchain_mcp_adapters.sessions import Connection
+from langchain_mcp_adapters.sessions import Connection, create_session
 from langchain_core.callbacks import Callbacks
 
 def convert_mcp_resource_to_langchain_blob(
@@ -256,7 +256,7 @@ async def load_mcp_resources_as_tools(
     list_tool = StructuredTool(
         name="list_resources",
         description=(
-            "List available MCP resources. Resources are data sources that can be read. "
+            "List available resources. Resources are data sources that can be read. "
             "Returns a list of resources with their URIs, names, descriptions, and MIME types. "
             "Supports pagination via the cursor parameter. "
             "Use this to discover what resources are available before reading them."
@@ -268,7 +268,7 @@ async def load_mcp_resources_as_tools(
     read_tool = StructuredTool(
         name="read_resource",
         description=(
-            "Read the contents of a specific MCP resource by its URI. "
+            "Read the contents of a specific resource by its URI. "
             "Returns the resource contents which may include text, binary data, or both. "
             "Use list_resources first to discover available resource URIs."
         ),

--- a/langchain_mcp_adapters/resources.py
+++ b/langchain_mcp_adapters/resources.py
@@ -5,11 +5,15 @@ objects, handling both text and binary resource content types.
 """  # noqa: E501
 
 import base64
+from typing import Any
 
 from langchain_core.documents.base import Blob
+from langchain_core.tools import BaseTool, StructuredTool
 from mcp import ClientSession
 from mcp.types import BlobResourceContents, ResourceContents, TextResourceContents
-
+from pydantic import BaseModel, Field
+from langchain_mcp_adapters.sessions import Connection
+from langchain_core.callbacks import Callbacks
 
 def convert_mcp_resource_to_langchain_blob(
     resource_uri: str, contents: ResourceContents
@@ -101,3 +105,176 @@ async def load_mcp_resources(
         raise RuntimeError(msg) from e
 
     return blobs
+
+
+# Pydantic schemas for tool arguments
+class ListResourcesInput(BaseModel):
+    """Input schema for list_resources tool."""
+
+    cursor: str | None = Field(
+        default=None,
+        description="Pagination cursor returned from a previous list_resources call. "
+        "If provided, returns the next page of results.",
+    )
+
+
+class ReadResourceInput(BaseModel):
+    """Input schema for read_resource tool."""
+
+    uri: str = Field(
+        description="The URI of the resource to read. "
+        "Use list_resources to discover available resource URIs."
+    )
+
+
+async def load_mcp_resources_as_tools(
+    session: ClientSession | None,
+    *,
+    connection: Connection | None = None,
+    callbacks: Callbacks | None = None,
+    server_name: str | None = None,
+) -> list[BaseTool]:
+    """Load MCP resources as LangChain tools for listing and reading resources.
+
+    This function creates two tools that an agent can use to interact with MCP resources:
+    - `list_resources`: Lists available resources with pagination support
+    - `read_resource`: Reads a specific resource by URI and returns its contents
+
+    Args:
+        session: The MCP client session. If `None`, connection must be provided.
+        connection: Connection config to create a new session if session is `None`.
+        callbacks: Optional `Callbacks` for handling notifications and events.
+        server_name: Name of the server these resources belong to.
+
+    Returns:
+        A list of two LangChain tools: list_resources and read_resource.
+
+    Raises:
+        ValueError: If neither session nor connection is provided.
+
+    Example:
+        ```python
+        from langchain_mcp_adapters.resources import load_mcp_resources_as_tools
+        from langchain_mcp_adapters.sessions import create_session
+
+        connection = {
+            "command": "uvx",
+            "args": ["mcp-server-fetch"],
+            "transport": "stdio",
+        }
+
+        async with create_session(connection) as session:
+            await session.initialize()
+            tools = await load_mcp_resources_as_tools(session)
+            # tools can now be used by an agent
+        ```
+    """  # noqa: E501
+    if session is None and connection is None:
+        msg = "Either a session or a connection config must be provided"
+        raise ValueError(msg)
+
+    mcp_callbacks = (
+        callbacks.to_mcp_format(context=CallbackContext(server_name=server_name))
+        if callbacks is not None
+        else []
+    )
+
+    async def list_resources_fn(cursor: str | None = None) -> dict[str, Any]:
+        """List available MCP resources with pagination support.
+
+        Args:
+            cursor: Optional pagination cursor from a previous call.
+
+        Returns:
+            A dictionary containing:
+                - resources: List of resource dictionaries with uri, name, description, mimeType
+                - nextCursor: Pagination cursor for the next page (if available)
+        """
+        if session is None:
+            if connection is None:
+                msg = "Either session or connection must be provided"
+                raise ValueError(msg)
+            async with create_session(
+                connection, mcp_callbacks=mcp_callbacks
+            ) as resource_session:
+                await resource_session.initialize()
+                result = await resource_session.list_resources(cursor=cursor)
+        else:
+            result = await session.list_resources(cursor=cursor)
+
+        resources = [
+            {
+                "uri": str(r.uri),
+                "name": r.name,
+                "description": r.description,
+                "mimeType": r.mimeType,
+            }
+            for r in (result.resources or [])
+        ]
+
+        return {
+            "resources": resources,
+            "nextCursor": result.nextCursor,
+        }
+
+    async def read_resource_fn(uri: str) -> dict[str, Any]:
+        """Read a specific MCP resource by URI.
+
+        Args:
+            uri: The URI of the resource to read.
+
+        Returns:
+            A dictionary containing:
+                - uri: The resource URI
+                - contents: List of content dictionaries with type, data, and mimeType
+        """
+        blobs = await get_mcp_resource(
+            session,
+            uri
+        )
+
+        contents = []
+        for blob in blobs:
+            content_dict = {
+                "mimeType": blob.mimetype,
+            }
+            # Return text as string, binary as base64
+            if isinstance(blob.data, str):
+                content_dict["type"] = "text"
+                content_dict["data"] = blob.data
+            else:
+                content_dict["type"] = "blob"
+                content_dict["data"] = base64.b64encode(blob.data).decode()
+
+            contents.append(content_dict)
+
+        return {
+            "uri": uri,
+            "contents": contents,
+        }
+
+    list_tool = StructuredTool(
+        name="list_resources",
+        description=(
+            "List available MCP resources. Resources are data sources that can be read. "
+            "Returns a list of resources with their URIs, names, descriptions, and MIME types. "
+            "Supports pagination via the cursor parameter. "
+            "Use this to discover what resources are available before reading them."
+        ),
+        args_schema=ListResourcesInput,
+        coroutine=list_resources_fn,
+    )
+
+    read_tool = StructuredTool(
+        name="read_resource",
+        description=(
+            "Read the contents of a specific MCP resource by its URI. "
+            "Returns the resource contents which may include text, binary data, or both. "
+            "Use list_resources first to discover available resource URIs."
+        ),
+        args_schema=ReadResourceInput,
+        coroutine=read_resource_fn,
+    )
+
+    return [list_tool, read_tool]
+


### PR DESCRIPTION
### Summary
Introduce tools for listing and reading MCP resources, enhancing interaction capabilities with resource management.

Adresses: [Issue 159](https://github.com/langchain-ai/langchain/issues/40489)

### Features
* Adds an `load_mcp_resources_as_tools` similar to the tools
* Offers the list and read functions from the [MCP Specification](https://modelcontextprotocol.io/specification/2025-06-18/server/resources)
* Can be used in agents as regular tools and allows MCP server to query resources for URIs returned by other tool calls
* Leaves existing implementation untouched
