### PR TITLE
feat: inject runtime arg for ToolRuntime access

### DIFF
--- a/langchain_mcp_adapters/interceptors.py
+++ b/langchain_mcp_adapters/interceptors.py
@@ -12,14 +12,14 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from langchain_core.messages import ToolMessage
 from mcp.types import CallToolResult
 from typing_extensions import NotRequired, TypedDict, Unpack
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-
-MCPToolCallResult = CallToolResult
+MCPToolCallResult = CallToolResult | ToolMessage
 
 
 class _MCPToolCallRequestOverrides(TypedDict, total=False):


### PR DESCRIPTION
Theoretically allows for access to tool call id, state, etc when available in a LG context (like with `create_agent`).

This works w/ the new `langgraph-prebuilt` and `langchain-core`.

```py
import asyncio
from mcp import ClientSession, StdioServerParameters
from mcp.client.stdio import stdio_client
from langchain.agents import create_agent
from langchain_mcp_adapters.interceptors import MCPToolCallRequest
from langchain_mcp_adapters.tools import load_mcp_tools
from langchain_openai import ChatOpenAI
from mcp.types import CallToolResult
from typing_extensions import TypedDict


async def main():

    async def runtime_interceptor(
        request: MCPToolCallRequest, handler
    ) -> CallToolResult:
        print(request.runtime.tool_call_id)
        print(request.runtime.context)
        print(request.runtime.state)
        return await handler(request)

    server_params = StdioServerParameters(
        command="python",
        args=["./math_server.py"],
    )

    async with stdio_client(server_params) as (read, write):
        async with ClientSession(read, write) as session:
            await session.initialize()

            tools = await load_mcp_tools(
                session, tool_interceptors=[runtime_interceptor]
            )

            class ContextSchema(TypedDict):
                user_id: str

            agent = create_agent(
                model=ChatOpenAI(model="gpt-4o-mini"),
                tools=tools,
                context_schema=ContextSchema,
            )
            await agent.ainvoke(
                {"messages": [{"role": "user", "content": "What is 5 + 3?"}]},
                context={"user_id": "123"},
            )

if __name__ == "__main__":
    asyncio.run(main())

"""
[11/21/25 10:02:42] INFO     Processing request of type ListToolsRequest                            server.py:674
call_f3Unpu6pMXc3erYy2U540a8s
{'user_id': '123'}
{'messages': [HumanMessage(content='What is 5 + 3?', additional_kwargs={}, response_metadata={}, id='ca0e9e84-34a0-4540-b92f-bcf023316562'), AIMessage(content='', additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 17, 'prompt_tokens': 73, 'total_tokens': 90, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_provider': 'openai', 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_560af6e559', 'id': 'chatcmpl-CeMwlKviSagQxVwtkocmYe9YzNlRb', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='lc_run--f8fff704-5f76-4526-8dbd-62878b5fbc15-0', tool_calls=[{'name': 'add', 'args': {'a': 5, 'b': 3}, 'id': 'call_f3Unpu6pMXc3erYy2U540a8s', 'type': 'tool_call'}], usage_metadata={'input_tokens': 73, 'output_tokens': 17, 'total_tokens': 90, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}
[11/21/25 10:02:44] INFO     Processing request of type CallToolRequest 
"""
```