### PR TITLE
Added `get_prompts` to the `MultiServerMCPClients`

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -14,6 +14,7 @@ from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from mcp import ClientSession
+from mcp.types import Prompt
 
 from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks
 from langchain_mcp_adapters.interceptors import ToolCallInterceptor
@@ -201,6 +202,14 @@ class MultiServerMCPClient:
         """Get a prompt from a given MCP server."""
         async with self.session(server_name) as session:
             return await load_mcp_prompt(session, prompt_name, arguments=arguments)
+
+    async def get_prompts(
+        self, server_name: str, *, cursor: str | None = None
+    ) -> list[Prompt]:
+        """Get prompts from a given MCP server."""
+        async with self.session(server_name) as session:
+            prompts = await session.list_prompts(cursor=cursor)
+            return prompts.prompts
 
     async def get_resources(
         self,

--- a/tests/servers/math_server.py
+++ b/tests/servers/math_server.py
@@ -28,5 +28,32 @@ def configure_assistant(skills: str) -> list[dict]:
     ]
 
 
+@mcp.prompt()
+def math_problem_solver(problem_type: str) -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": (
+                f"You are a math expert specializing in {problem_type}. "
+                "Provide step-by-step solutions to problems."
+            ),
+        },
+    ]
+
+
+@mcp.prompt()
+def calculation_guide() -> list[dict]:
+    return [
+        {
+            "role": "assistant",
+            "content": (
+                "You are a calculation guide. "
+                "Help users understand how to perform "
+                "mathematical operations correctly."
+            ),
+        },
+    ]
+
+
 if __name__ == "__main__":
     mcp.run(transport="stdio")


### PR DESCRIPTION
This PR adds the `get_prompts` method to the `MultiServerMCPClients` class to expose the same functionality as `get_tools` and `get_resources`.

Fix: langchain-ai/langchain#40490