### PR TITLE
fix: require langchain-core 1.0.0 to use std content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "langchain-core>=0.3.36,<2.0.0",
+    "langchain-core>=1.0.0,<2.0.0",
     "mcp>=1.9.2",
     "typing-extensions>=4.14.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-core", specifier = ">=0.3.36,<2.0.0" },
+    { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
     { name = "mcp", specifier = ">=1.9.2" },
     { name = "typing-extensions", specifier = ">=4.14.0" },
 ]


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchain-mcp-adapters/issues/391