### PR TITLE
Fix CVE-2025-68664

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "langchain-core>=1.0.0,<2.0.0",
+    "langchain-core>=1.2.5,<2.0.0",
     "mcp>=1.9.2",
     "typing-extensions>=4.14.0",
 ]


### PR DESCRIPTION
CVE is critical.

Please see: https://cyata.ai/blog/langgrinch-langchain-core-cve-2025-68664/
