### PR TITLE
feat: pass _meta parameter through to MCP SDK call_tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,43 @@ response = await agent.ainvoke({"messages": "what is the weather in nyc?"})
 
 > Only `sse` and `http` transports support runtime headers. These headers are passed with every HTTP request to the MCP server.
 
+## Passing request metadata (`_meta`)
+
+MCP supports passing metadata with each tool invocation via the `_meta` parameter. This is useful for:
+- Passing request-specific context to servers
+- Custom routing or multi-tenant scenarios
+
+### Example: passing `_meta` with tool invocation
+
+```python
+# Pass _meta as part of tool arguments
+result = await tool.ainvoke({
+    "message": "hello",
+    "_meta": {"session_id": "abc123"}
+})
+```
+
+### Example: adding `_meta` via interceptor
+
+```python
+from langchain_mcp_adapters.tools import load_mcp_tools
+
+async def add_context_interceptor(request, handler):
+    """Add request context via _meta."""
+    modified = request.override(
+        meta={"user_id": "current-user-id"}
+    )
+    return await handler(modified)
+
+tools = await load_mcp_tools(
+    None,
+    connection={"url": "http://localhost:8000/mcp", "transport": "http"},
+    tool_interceptors=[add_context_interceptor],
+)
+```
+
+> Per the [MCP specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/index#meta), `_meta` is reserved for protocol-level metadata.
+
 ## Using with LangGraph StateGraph
 
 ```python

--- a/langchain_mcp_adapters/interceptors.py
+++ b/langchain_mcp_adapters/interceptors.py
@@ -46,6 +46,7 @@ class _MCPToolCallRequestOverrides(TypedDict, total=False):
     name: NotRequired[str]
     args: NotRequired[dict[str, Any]]
     headers: NotRequired[dict[str, Any] | None]
+    meta: NotRequired[dict[str, Any] | None]
 
 
 @dataclass
@@ -60,6 +61,7 @@ class MCPToolCallRequest:
         name: Tool name to invoke.
         args: Tool arguments as key-value pairs.
         headers: HTTP headers for applicable transports (SSE, HTTP).
+        meta: MCP protocol metadata (_meta) to pass to the server.
 
     Context fields (read-only, use for routing/logging):
         server_name: Name of the MCP server handling the tool.
@@ -70,6 +72,7 @@ class MCPToolCallRequest:
     args: dict[str, Any]
     server_name: str  # Context: MCP server name
     headers: dict[str, Any] | None = None  # Modifiable: HTTP headers
+    meta: dict[str, Any] | None = None  # Modifiable: MCP _meta protocol metadata
     runtime: object | None = None  # Context: LangGraph runtime (if any)
 
     def override(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -441,7 +441,7 @@ async def test_convert_mcp_tool_to_langchain_tool():
 
     # Verify session.call_tool was called with correct arguments
     session.call_tool.assert_called_once_with(
-        "test_tool", {"param1": "test", "param2": 42}, progress_callback=None
+        "test_tool", {"param1": "test", "param2": 42}, progress_callback=None, meta=None
     )
 
     # Verify result
@@ -479,7 +479,7 @@ async def test_load_mcp_tools():
     session.list_tools.return_value = MagicMock(tools=mcp_tools, nextCursor=None)
 
     # Mock call_tool to return different results for different tools
-    async def mock_call_tool(tool_name, arguments, progress_callback=None):
+    async def mock_call_tool(tool_name, arguments, progress_callback=None, meta=None):
         if tool_name == "tool1":
             return CallToolResult(
                 content=[


### PR DESCRIPTION
## Summary
- Enables the MCP protocol's `_meta` parameter to be passed through to MCP servers when invoking tools
- Adds `meta` field to `MCPToolCallRequest` dataclass and `_MCPToolCallRequestOverrides` for interceptor support
- Extracts `_meta` from tool arguments and passes it to `session.call_tool()`

## Related Issue
Proposal for langchain-ai/langchain#40480

## How It Works
When invoking an MCP tool, you can include a `_meta` field in the tool arguments. This metadata is extracted from the arguments and passed through to the MCP server via `session.call_tool()`.

For example, to pass a correlation ID or user ID for tracing/auditing purposes:

```python
# When invoking a tool, include _meta in the arguments
tool_args = {
    "query": "search term",
    "_meta": {
        "correlationId": "abc-123-xyz",
        "userId": "user_456",
        "requestSource": "web-app"
    }
}
```

The MCP server receives the `_meta` object as part of the `CallToolRequest`, allowing it to:
- Track requests across distributed systems using correlation IDs
- Implement user-specific logic or audit logging
- Route requests based on custom metadata in multi-tenant scenarios

## Changes
- Added `meta` field to `MCPToolCallRequest` dataclass
- Added `meta` to `_MCPToolCallRequestOverrides` for interceptor support  
- Extract `_meta` from tool arguments and pass to `session.call_tool()`
- Added tests for `_meta` passthrough functionality
- Added documentation for `_meta` usage in README

## MCP Specification Reference
Per the MCP spec (2025-06-18), `_meta` is reserved to allow clients and servers to attach additional metadata to their interactions, including:
- Custom routing and context information
- Server-specific metadata for multi-tenant or federated scenarios