### PR TITLE
feat(client): add long-lived multi-server client that reuses sessions…

### DIFF
--- a/langchain_mcp_adapters/__init__.py
+++ b/langchain_mcp_adapters/__init__.py
@@ -4,3 +4,13 @@ This package provides adapters to connect MCP (Model Context Protocol) servers
 with LangChain applications, converting MCP tools, prompts, and resources into
 LangChain-compatible formats.
 """
+
+from langchain_mcp_adapters.client import (
+    LongLivedMultiServerMCPClient,
+    MultiServerMCPClient,
+)
+
+__all__ = [
+    "LongLivedMultiServerMCPClient",
+    "MultiServerMCPClient",
+]

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -6,6 +6,7 @@ to multiple MCP servers and loading tools, prompts, and resources from them.
 
 import asyncio
 from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager
 from contextlib import asynccontextmanager
 from types import TracebackType
 from typing import Any
@@ -279,8 +280,188 @@ class MultiServerMCPClient:
         raise NotImplementedError(ASYNC_CONTEXT_MANAGER_ERROR)
 
 
+class LongLivedMultiServerMCPClient(MultiServerMCPClient):
+    """A `MultiServerMCPClient` variant that keeps sessions alive across tool calls.
+
+    Use this class as an async context manager:
+
+    ```python
+    async with LongLivedMultiServerMCPClient(connections) as client:
+        tools = await client.get_tools()
+    ```
+
+    In this mode, tools loaded by `get_tools()` will reuse long-lived server sessions.
+    """
+
+    def __init__(
+        self,
+        connections: dict[str, Connection] | None = None,
+        *,
+        callbacks: Callbacks | None = None,
+        tool_interceptors: list[ToolCallInterceptor] | None = None,
+        tool_name_prefix: bool = False,
+    ) -> None:
+        super().__init__(
+            connections=connections,
+            callbacks=callbacks,
+            tool_interceptors=tool_interceptors,
+            tool_name_prefix=tool_name_prefix,
+        )
+        self.sessions: dict[str, ClientSession] = {}
+        self._session_cms: dict[str, AbstractAsyncContextManager[ClientSession]] = {}
+
+    async def start(self) -> None:
+        """Start long-lived sessions for all configured servers."""
+        for server_name in self.connections:
+            if server_name not in self.sessions:
+                await self._create_session_for_server(server_name)
+
+    async def _create_session_for_server(self, server_name: str) -> None:
+        cm = self.session(server_name, auto_initialize=True)
+        session = await cm.__aenter__()
+        self.sessions[server_name] = session
+        self._session_cms[server_name] = cm
+
+    async def stop(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
+    ) -> None:
+        """Close all long-lived sessions."""
+        for cm in self._session_cms.values():
+            await cm.__aexit__(exc_type, exc_val, exc_tb)
+        self.sessions.clear()
+        self._session_cms.clear()
+
+    async def get_tools(self, *, server_name: str | None = None) -> list[BaseTool]:
+        """Get tools, preferring long-lived sessions when available."""
+        if server_name is not None:
+            if server_name not in self.connections:
+                msg = (
+                    f"Couldn't find a server with name '{server_name}', "
+                    f"expected one of '{list(self.connections.keys())}'"
+                )
+                raise ValueError(msg)
+
+            session = self.sessions.get(server_name)
+            if session is not None:
+                return await load_mcp_tools(
+                    session,
+                    callbacks=self.callbacks,
+                    server_name=server_name,
+                    tool_interceptors=self.tool_interceptors,
+                    tool_name_prefix=self.tool_name_prefix,
+                )
+
+            return await load_mcp_tools(
+                None,
+                connection=self.connections[server_name],
+                callbacks=self.callbacks,
+                server_name=server_name,
+                tool_interceptors=self.tool_interceptors,
+                tool_name_prefix=self.tool_name_prefix,
+            )
+
+        all_tools: list[BaseTool] = []
+        load_mcp_tool_tasks = []
+        for name, connection in self.connections.items():
+            session = self.sessions.get(name)
+            load_mcp_tool_task = asyncio.create_task(
+                load_mcp_tools(
+                    session,
+                    connection=None if session is not None else connection,
+                    callbacks=self.callbacks,
+                    server_name=name,
+                    tool_interceptors=self.tool_interceptors,
+                    tool_name_prefix=self.tool_name_prefix,
+                )
+            )
+            load_mcp_tool_tasks.append(load_mcp_tool_task)
+        tools_list = await asyncio.gather(*load_mcp_tool_tasks)
+        for tools in tools_list:
+            all_tools.extend(tools)
+        return all_tools
+
+    async def get_prompt(
+        self,
+        server_name: str,
+        prompt_name: str,
+        *,
+        arguments: dict[str, Any] | None = None,
+    ) -> list[HumanMessage | AIMessage]:
+        """Get a prompt, preferring long-lived sessions when available."""
+        if server_name not in self.connections:
+            msg = (
+                f"Couldn't find a server with name '{server_name}', "
+                f"expected one of '{list(self.connections.keys())}'"
+            )
+            raise ValueError(msg)
+
+        session = self.sessions.get(server_name)
+        if session is not None:
+            return await load_mcp_prompt(session, prompt_name, arguments=arguments)
+
+        async with self.session(server_name) as ephemeral_session:
+            return await load_mcp_prompt(
+                ephemeral_session, prompt_name, arguments=arguments
+            )
+
+    async def get_resources(
+        self,
+        server_name: str | None = None,
+        *,
+        uris: str | list[str] | None = None,
+    ) -> list[Blob]:
+        """Get resources, preferring long-lived sessions when available."""
+        if server_name is not None:
+            if server_name not in self.connections:
+                msg = (
+                    f"Couldn't find a server with name '{server_name}', "
+                    f"expected one of '{list(self.connections.keys())}'"
+                )
+                raise ValueError(msg)
+
+            session = self.sessions.get(server_name)
+            if session is not None:
+                return await load_mcp_resources(session, uris=uris)
+
+            async with self.session(server_name) as ephemeral_session:
+                return await load_mcp_resources(ephemeral_session, uris=uris)
+
+        async def _load_resources_from_server(name: str) -> list[Blob]:
+            session = self.sessions.get(name)
+            if session is not None:
+                return await load_mcp_resources(session, uris=uris)
+            async with self.session(name) as ephemeral_session:
+                return await load_mcp_resources(ephemeral_session, uris=uris)
+
+        all_resources: list[Blob] = []
+        load_tasks = [
+            asyncio.create_task(_load_resources_from_server(name))
+            for name in self.connections
+        ]
+        resources_list = await asyncio.gather(*load_tasks)
+        for resources in resources_list:
+            all_resources.extend(resources)
+        return all_resources
+
+    async def __aenter__(self) -> "LongLivedMultiServerMCPClient":
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        await self.stop(exc_type, exc_val, exc_tb)
+
+
 __all__ = [
     "Callbacks",
+    "LongLivedMultiServerMCPClient",
     "McpHttpClientFactory",
     "MultiServerMCPClient",
     "SSEConnection",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,15 @@
 import os
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage
 from langchain_core.tools import BaseTool
 
-from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.client import (
+    LongLivedMultiServerMCPClient,
+    MultiServerMCPClient,
+)
 from langchain_mcp_adapters.tools import load_mcp_tools
 from tests.utils import IsLangChainID
 
@@ -167,6 +171,108 @@ async def test_get_prompt():
     assert isinstance(messages[0], AIMessage)
     assert "You are a helpful assistant" in messages[0].content
     assert "math, addition, multiplication" in messages[0].content
+
+
+async def test_long_lived_client_uses_persistent_session_for_load_mcp_tools(
+    monkeypatch,
+):
+    """Verify get_tools() uses the already-open session with load_mcp_tools()."""
+    client = LongLivedMultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": ["unused"],
+                "transport": "stdio",
+            }
+        }
+    )
+    persistent_session = AsyncMock()
+    client.sessions["math"] = persistent_session
+
+    fake_tool = AsyncMock()
+
+    async def fake_load_mcp_tools(session, **kwargs):
+        assert session is persistent_session
+        assert kwargs["server_name"] == "math"
+        assert kwargs["callbacks"] is client.callbacks
+        assert kwargs["tool_name_prefix"] is False
+        return [fake_tool]
+
+    monkeypatch.setattr(
+        "langchain_mcp_adapters.client.load_mcp_tools",
+        fake_load_mcp_tools,
+    )
+
+    tools = await client.get_tools(server_name="math")
+    assert tools == [fake_tool]
+
+
+async def test_long_lived_client_uses_persistent_session_for_get_prompt(monkeypatch):
+    client = LongLivedMultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": ["unused"],
+                "transport": "stdio",
+            }
+        }
+    )
+    persistent_session = AsyncMock()
+    client.sessions["math"] = persistent_session
+
+    expected_messages = [AIMessage(content="ok")]
+
+    async def fake_load_mcp_prompt(session, prompt_name, arguments=None):
+        assert session is persistent_session
+        assert prompt_name == "configure_assistant"
+        assert arguments == {"skills": "math"}
+        return expected_messages
+
+    monkeypatch.setattr(
+        "langchain_mcp_adapters.client.load_mcp_prompt",
+        fake_load_mcp_prompt,
+    )
+
+    messages = await client.get_prompt(
+        "math",
+        "configure_assistant",
+        arguments={"skills": "math"},
+    )
+    assert messages == expected_messages
+
+
+async def test_long_lived_client_uses_persistent_session_for_get_resources(
+    monkeypatch,
+):
+    client = LongLivedMultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": ["unused"],
+                "transport": "stdio",
+            }
+        }
+    )
+    persistent_session = AsyncMock()
+    client.sessions["math"] = persistent_session
+
+    expected_resources = [Blob(data="E = mc^2", mimetype="text/plain", metadata={})]
+
+    async def fake_load_mcp_resources(session, uris=None):
+        assert session is persistent_session
+        assert uris == "math://formulas"
+        return expected_resources
+
+    monkeypatch.setattr(
+        "langchain_mcp_adapters.client.load_mcp_resources",
+        fake_load_mcp_resources,
+    )
+
+    resources = await client.get_resources(
+        server_name="math",
+        uris="math://formulas",
+    )
+    assert resources == expected_resources
 
 
 async def test_get_resources_from_all_servers():


### PR DESCRIPTION
## Summary

This PR adds a new client class, `LongLivedMultiServerMCPClient`, to enable long-lived MCP sessions and ensure those sessions are actually reused by high-level APIs.

## Problem

Even when a long-lived session was opened, `get_tools()` could still load tools through `load_mcp_tools(session=None, connection=...)`, which caused tool execution to create fresh sessions instead of using the persistent one.

## Changes

- Added `LongLivedMultiServerMCPClient` in `langchain_mcp_adapters/client.py`.
- Added lifecycle methods:
  - `start()`
  - `stop()`
  - `__aenter__()`
  - `__aexit__()`
- Overrode:
  - `get_tools()` to use `self.sessions[server_name]` when available.
  - `get_prompt()` to use persistent sessions when available.
  - `get_resources()` to use persistent sessions when available (single server and all servers modes).
- Exported `LongLivedMultiServerMCPClient` via `langchain_mcp_adapters/__init__.py`.
- Added tests in `tests/test_client.py` to verify persistent-session reuse for:
  - `get_tools()`
  - `get_prompt()`
  - `get_resources()`

## Why this fixes it

When a persistent session exists, all three APIs now call loaders with that active `ClientSession` directly. This avoids per-call session creation and preserves server-side state in long-lived workflows.

## Related issues

- Closes langchain-ai/langchain-mcp-adapters#362
- Closes langchain-ai/langchain#40487

## Testing

Added targeted unit tests for the new behavior.