### PR TITLE
fix: return plain string for single text content in MCP tool results

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -195,6 +195,16 @@ def _convert_call_tool_result(
             structured_content=call_tool_result.structuredContent
         )
 
+    # If there is only a single text content block, return as a plain string
+    # for compatibility with LLM APIs that expect string tool message content
+    # (e.g. OpenAI). Multi-block or non-text results remain as list.
+    if (
+        len(tool_content) == 1
+        and isinstance(tool_content[0], dict)
+        and tool_content[0].get("type") == "text"
+    ):
+        return tool_content[0]["text"], artifact
+
     return tool_content, artifact
 
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -118,11 +118,8 @@ async def test_callbacks_with_mcp_tool_execution(socket_enabled) -> None:
         result = await tool.ainvoke(
             {"args": {"task": "test"}, "id": "1", "type": "tool_call"}
         )
-        assert any(
-            "Executed: test" in block.get("text", "")
-            for block in result.content
-            if isinstance(block, dict)
-        )
+        # Single text content is returned as a plain string
+        assert "Executed: test" in result.content
 
         # Verify both progress and logging callbacks were called
         await asyncio.sleep(0.05)  # Give time for callbacks to complete

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -72,24 +72,22 @@ async def test_multi_server_mcp_client(
     # Test that we can call a math tool
     add_tool = next(tool for tool in all_tools if tool.name == "add")
     result = await add_tool.ainvoke({"a": 2, "b": 3})
-    assert result == [{"type": "text", "text": "5", "id": IsLangChainID}]
+    assert result == "5"
 
     # Test that we can call a weather tool
     weather_tool = next(tool for tool in all_tools if tool.name == "get_weather")
     result = await weather_tool.ainvoke({"location": "London"})
-    assert result == [
-        {"type": "text", "text": "It's always sunny in London", "id": IsLangChainID}
-    ]
+    assert result == "It's always sunny in London"
 
     # Test the multiply tool
     multiply_tool = next(tool for tool in all_tools if tool.name == "multiply")
     result = await multiply_tool.ainvoke({"a": 4, "b": 5})
-    assert result == [{"type": "text", "text": "20", "id": IsLangChainID}]
+    assert result == "20"
 
     # Test that we can call a time tool
     time_tool = next(tool for tool in all_tools if tool.name == "get_time")
     result = await time_tool.ainvoke({"args": ""})
-    assert result == [{"type": "text", "text": "5:20:00 PM EST", "id": IsLangChainID}]
+    assert result == "5:20:00 PM EST"
 
 
 async def test_multi_server_connect_methods(
@@ -121,7 +119,7 @@ async def test_multi_server_connect_methods(
         tools = await load_mcp_tools(session)
         assert len(tools) == 2
         result = await tools[0].ainvoke({"a": 2, "b": 3})
-        assert result == [{"type": "text", "text": "5", "id": IsLangChainID}]
+        assert result == "5"
 
         for tool in tools:
             tool_names.add(tool.name)
@@ -130,9 +128,7 @@ async def test_multi_server_connect_methods(
         tools = await load_mcp_tools(session)
         assert len(tools) == 1
         result = await tools[0].ainvoke({"args": ""})
-        assert result == [
-            {"type": "text", "text": "5:20:00 PM EST", "id": IsLangChainID}
-        ]
+        assert result == "5:20:00 PM EST"
 
         for tool in tools:
             tool_names.add(tool.name)

--- a/tests/test_interceptors.py
+++ b/tests/test_interceptors.py
@@ -88,7 +88,7 @@ class TestInterceptorModifiesRequest:
             add_tool = next(tool for tool in tools if tool.name == "add")
             # Call add but interceptor redirects to multiply: 5 * 2 = 10
             result = await add_tool.ainvoke({"a": 5, "b": 2})
-            assert result == [{"type": "text", "text": "10", "id": IsLangChainID}]
+            assert result == "10"
 
 
 class TestInterceptorModifiesResponse:
@@ -131,9 +131,7 @@ class TestInterceptorModifiesResponse:
 
             add_tool = next(tool for tool in tools if tool.name == "add")
             result = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result == [
-                {"type": "text", "text": "Modified: 5", "id": IsLangChainID}
-            ]
+            assert result == "Modified: 5"
 
     async def test_interceptor_returns_custom_result(self, socket_enabled):
         """Test that interceptor can return a completely custom CallToolResult."""
@@ -160,9 +158,7 @@ class TestInterceptorModifiesResponse:
 
             add_tool = next(tool for tool in tools if tool.name == "add")
             result = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result == [
-                {"type": "text", "text": "Custom tool response", "id": IsLangChainID}
-            ]
+            assert result == "Custom tool response"
 
 
 class TestInterceptorAdvancedPatterns:
@@ -202,17 +198,17 @@ class TestInterceptorAdvancedPatterns:
 
             # First call - should execute
             result1 = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result1 == [{"type": "text", "text": "5", "id": IsLangChainID}]
+            assert result1 == "5"
             assert call_count == 1
 
             # Second call with same args - should use cache
             result2 = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result2 == [{"type": "text", "text": "5", "id": IsLangChainID}]
+            assert result2 == "5"
             assert call_count == 1  # Should not increment
 
             # Third call with different args - should execute
             result3 = await add_tool.ainvoke({"a": 5, "b": 7})
-            assert result3 == [{"type": "text", "text": "12", "id": IsLangChainID}]
+            assert result3 == "12"
             assert call_count == 2
 
 
@@ -254,7 +250,7 @@ class TestInterceptorComposition:
 
             add_tool = next(tool for tool in tools if tool.name == "add")
             result = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result == [{"type": "text", "text": "5", "id": IsLangChainID}]
+            assert result == "5"
 
             # Should execute in onion order: 1 before, 2 before, execute, 2 after,
             # 1 after

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -56,7 +56,8 @@ def test_convert_single_text_content():
 
     content, artifact = _convert_call_tool_result(result)
 
-    assert content == [{"type": "text", "text": "test result", "id": IsLangChainID}]
+    # Single text content should be returned as a plain string
+    assert content == "test result"
     assert artifact is None
 
 
@@ -141,7 +142,8 @@ def test_convert_with_structured_content():
 
     content, artifact = _convert_call_tool_result(result)
 
-    assert content == [{"type": "text", "text": "text result", "id": IsLangChainID}]
+    # Single text content should be returned as a plain string
+    assert content == "text result"
     assert artifact == MCPToolArtifact(
         structured_content={"key": "value", "nested": {"data": 123}}
     )
@@ -447,9 +449,8 @@ async def test_convert_mcp_tool_to_langchain_tool():
     # Verify result
     assert result.name == "test_tool"
     assert result.tool_call_id == "1"
-    assert result.content == [
-        {"type": "text", "text": "tool result", "id": IsLangChainID}
-    ]
+    # Single text content should be a plain string
+    assert result.content == "tool result"
 
 
 async def test_load_mcp_tools():
@@ -509,13 +510,7 @@ async def test_load_mcp_tools():
     )
     assert result1.name == "tool1"
     assert result1.tool_call_id == "1"
-    assert result1.content == [
-        {
-            "type": "text",
-            "text": "tool1 result with {'param1': 'test1', 'param2': 1}",
-            "id": IsLangChainID,
-        }
-    ]
+    assert result1.content == "tool1 result with {'param1': 'test1', 'param2': 1}"
 
     # Test calling the second tool
     result2 = await tools[1].ainvoke(
@@ -523,13 +518,7 @@ async def test_load_mcp_tools():
     )
     assert result2.name == "tool2"
     assert result2.tool_call_id == "2"
-    assert result2.content == [
-        {
-            "type": "text",
-            "text": "tool2 result with {'param1': 'test2', 'param2': 2}",
-            "id": IsLangChainID,
-        }
-    ]
+    assert result2.content == "tool2 result with {'param1': 'test2', 'param2': 2}"
 
 
 def _create_annotations_server():
@@ -732,9 +721,8 @@ async def test_load_mcp_tools_with_custom_httpx_client_factory(socket_enabled) -
 
         # Test that the tool works correctly
         result = await tool.ainvoke({"args": {}, "id": "1", "type": "tool_call"})
-        assert result.content == [
-            {"type": "text", "text": "Server is running", "id": IsLangChainID}
-        ]
+        # Single text content should be a plain string
+        assert result.content == "Server is running"
 
 
 def _create_info_server():
@@ -1109,22 +1097,11 @@ async def test_parallel_tool_invocation_across_multiple_servers(socket_enabled) 
         results_by_id = {msg.tool_call_id: msg.content for msg in tool_messages}
 
         # Verify the weather search was routed to the weather server
-        assert results_by_id["call_weather"] == [
-            {
-                "type": "text",
-                "text": "Weather results for: sunny in Paris",
-                "id": IsLangChainID,
-            }
-        ]
+        # Single text content is returned as a plain string
+        assert results_by_id["call_weather"] == "Weather results for: sunny in Paris"
 
         # Verify the flights search was routed to the flights server
-        assert results_by_id["call_flights"] == [
-            {
-                "type": "text",
-                "text": "Flight results to: Tokyo",
-                "id": IsLangChainID,
-            }
-        ]
+        assert results_by_id["call_flights"] == "Flight results to: Tokyo"
 
 
 async def test_get_tools_with_name_conflict(socket_enabled) -> None:


### PR DESCRIPTION
## Description

Fixes langchain-ai/langchain#34669

When an MCP tool returns a single `TextContent` block (the most common case), `_convert_call_tool_result()` currently wraps it in a list: `[{"type": "text", "text": "..."}]`. This list gets set as `ToolMessage.content`, which causes serialization failures with LLM APIs that expect a plain string (e.g. OpenAI’s API returns a 400 error).

### Root Cause

In `tools.py`, `_convert_call_tool_result()` always returns `tool_content` as a `list[dict]`, even when there is only a single text block. The `StructuredTool` with `response_format="content_and_artifact"` then sets this list directly as `ToolMessage.content`.

### Fix

Added a check before the return: if the result contains exactly one text content block, return the text as a plain string instead of a list. Multi-block and non-text results continue to return as a list, preserving existing behavior for complex content.

Thanks to @fzozyurt for the detailed root cause analysis in langchain-ai/langchain#34669.

## Test Plan

- [x] Updated `test_convert_single_text_content` to assert string return
- [x] Updated `test_convert_with_structured_content` to assert string return
- [x] Updated integration tests (`test_client.py`, `test_callbacks.py`, `test_interceptors.py`)
- [x] Verified multi-block content tests still pass (return list as before)
- [x] Verified non-text single content tests still pass (return list as before)
- [x] Full test suite: 67 passed, 2 skipped, 0 failed
