### PR TITLE
Fix trailing whitespace in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
-line-length = 88 
+line-length = 88
 target-version = "py310"
 
 [tool.ruff.lint]


### PR DESCRIPTION
Removes trailing whitespace from line 54 of pyproject.toml for cleaner formatting.