### PR TITLE
feat: add `get_server_info` to retrieve MCP server metadata

### DIFF
--- a/langchain_mcp_adapters/__init__.py
+++ b/langchain_mcp_adapters/__init__.py
@@ -2,5 +2,5 @@
 
 This package provides adapters to connect MCP (Model Context Protocol) servers
 with LangChain applications, converting MCP tools, prompts, and resources into
-LangChain-compatible formats.
+LangChain-compatible formats and exposing MCP server metadata.
 """

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -13,12 +13,11 @@ from typing import Any
 from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool
-from mcp import ClientSession
-
 from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks
 from langchain_mcp_adapters.interceptors import ToolCallInterceptor
 from langchain_mcp_adapters.prompts import load_mcp_prompt
 from langchain_mcp_adapters.resources import load_mcp_resources
+from langchain_mcp_adapters.server_info import load_mcp_server_info
 from langchain_mcp_adapters.sessions import (
     Connection,
     McpHttpClientFactory,
@@ -29,6 +28,8 @@ from langchain_mcp_adapters.sessions import (
     create_session,
 )
 from langchain_mcp_adapters.tools import load_mcp_tools
+from mcp import ClientSession
+from mcp.types import InitializeResult
 
 ASYNC_CONTEXT_MANAGER_ERROR = (
     "As of langchain-mcp-adapters 0.1.0, MultiServerMCPClient cannot be used as a "
@@ -198,6 +199,29 @@ class MultiServerMCPClient:
         for tools in tools_list:
             all_tools.extend(tools)
         return all_tools
+
+    async def get_info(self) -> dict[str, InitializeResult]:
+        """Get server info from all connected MCP servers.
+
+        Returns the ``InitializeResult`` for each server, which includes
+        server instructions, capabilities, and implementation details.
+
+        Returns:
+            A dict mapping server names to their ``InitializeResult``.
+
+        """
+        tasks = [
+            asyncio.create_task(
+                load_mcp_server_info(
+                    connection=self.connections[name],
+                    callbacks=self.callbacks,
+                    server_name=name,
+                )
+            )
+            for name in self.connections
+        ]
+        results = await asyncio.gather(*tasks)
+        return dict(zip(self.connections.keys(), results))
 
     async def get_prompt(
         self,

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -215,11 +215,11 @@ class MultiServerMCPClient:
     async def get_info(self) -> dict[str, InitializeResult]:
         """Get server info from all connected MCP servers.
 
-        Returns the ``InitializeResult`` for each server, which includes
+        Returns the `InitializeResult` for each server, which includes
         server instructions, capabilities, and implementation details.
 
         Returns:
-            A dict mapping server names to their ``InitializeResult``.
+            A dict mapping server names to their `InitializeResult`.
 
         """
         tasks = [

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -1,7 +1,8 @@
 """Client for connecting to multiple MCP servers and loading LC tools/resources.
 
 This module provides the `MultiServerMCPClient` class for managing connections
-to multiple MCP servers and loading tools, prompts, and resources from them.
+to multiple MCP servers and loading tools, prompts, resources, and server info
+from them.
 """
 
 import asyncio
@@ -13,6 +14,9 @@ from typing import Any
 from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool
+from mcp import ClientSession
+from mcp.types import InitializeResult
+
 from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks
 from langchain_mcp_adapters.interceptors import ToolCallInterceptor
 from langchain_mcp_adapters.prompts import load_mcp_prompt
@@ -28,8 +32,6 @@ from langchain_mcp_adapters.sessions import (
     create_session,
 )
 from langchain_mcp_adapters.tools import load_mcp_tools
-from mcp import ClientSession
-from mcp.types import InitializeResult
 
 ASYNC_CONTEXT_MANAGER_ERROR = (
     "As of langchain-mcp-adapters 0.1.0, MultiServerMCPClient cannot be used as a "
@@ -46,7 +48,8 @@ ASYNC_CONTEXT_MANAGER_ERROR = (
 class MultiServerMCPClient:
     """Client for connecting to multiple MCP servers.
 
-    Loads LangChain-compatible tools, prompts and resources from MCP servers.
+    Loads LangChain-compatible tools, prompts and resources from MCP servers, and
+    retrieves server info from them.
     """
 
     def __init__(
@@ -212,28 +215,89 @@ class MultiServerMCPClient:
             all_tools.extend(tools)
         return all_tools
 
-    async def get_info(self) -> dict[str, InitializeResult]:
-        """Get server info from all connected MCP servers.
+    async def get_server_info(
+        self,
+        *,
+        server_name: str | None = None,
+    ) -> dict[str, InitializeResult]:
+        """Get server info from MCP server(s).
 
         Returns the `InitializeResult` for each server, which includes
         server instructions, capabilities, and implementation details.
 
+        Args:
+            server_name: Optional name of the server to get info from.
+                If `None`, info from all servers will be returned.
+
+        !!! note
+
+            A new temporary session is created for each server on every call and
+            results are not cached, so each call performs a fresh handshake with
+            every server queried (for `stdio` servers, that means starting a new
+            subprocess each time).
+
         Returns:
-            A dict mapping server names to their `InitializeResult`.
+            A dict mapping server names to their `InitializeResult`. Empty if no
+                connections are configured.
+
+        Raises:
+            ValueError: If `server_name` is provided but not found in the
+                connections.
+            RuntimeError: If any queried server fails. Every server is queried
+                and the message names each one that failed; partial results are
+                not returned.
 
         """
+        if server_name is not None:
+            if server_name not in self.connections:
+                msg = (
+                    f"Couldn't find a server with name '{server_name}', "
+                    f"expected one of '{list(self.connections.keys())}'"
+                )
+                raise ValueError(msg)
+            names = [server_name]
+        else:
+            # Snapshot the names before awaiting: `connections` is public and
+            # mutable, so re-reading it afterwards could misalign names with
+            # results.
+            names = list(self.connections)
+
         tasks = [
             asyncio.create_task(
                 load_mcp_server_info(
+                    None,
                     connection=self.connections[name],
                     callbacks=self.callbacks,
                     server_name=name,
                 )
             )
-            for name in self.connections
+            for name in names
         ]
-        results = await asyncio.gather(*tasks)
-        return dict(zip(self.connections.keys(), results))
+        # `return_exceptions=True` lets every task run to completion so each
+        # session unwinds its context manager (tearing down subprocesses and
+        # connections) instead of being orphaned mid-`async with`, and lets the
+        # error below name every server that failed rather than only the first.
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        server_info: dict[str, InitializeResult] = {}
+        errors: dict[str, BaseException] = {}
+        for name, result in zip(names, results, strict=True):
+            if isinstance(result, BaseException):
+                errors[name] = result
+            else:
+                server_info[name] = result
+
+        if errors:
+            detail = ", ".join(
+                f"'{name}': {type(exc).__name__}: {exc}" for name, exc in errors.items()
+            )
+            msg = (
+                f"Failed to retrieve server info from {len(errors)} of "
+                f"{len(names)} MCP server(s) - {detail}"
+            )
+            raise RuntimeError(msg) from next(iter(errors.values()))
+
+        return server_info
 
     async def get_prompt(
         self,

--- a/langchain_mcp_adapters/server_info.py
+++ b/langchain_mcp_adapters/server_info.py
@@ -1,0 +1,65 @@
+"""Server info adapter for retrieving MCP server metadata.
+
+This module provides functionality to retrieve server information
+from the MCP initialize handshake, including server instructions,
+capabilities, and implementation details.
+"""
+
+from mcp import ClientSession
+from mcp.types import InitializeResult
+
+from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks, _MCPCallbacks
+from langchain_mcp_adapters.sessions import Connection, create_session
+
+
+async def load_mcp_server_info(
+    session: ClientSession | None = None,
+    *,
+    connection: Connection | None = None,
+    callbacks: Callbacks | None = None,
+    server_name: str | None = None,
+) -> InitializeResult:
+    """Load server info from the MCP initialize handshake.
+
+    Returns the full `InitializeResult` from the MCP protocol, which includes
+    server instructions, capabilities, implementation details, and protocol
+    version.
+
+    Args:
+        session: An **uninitialized** MCP client session. If provided, this
+            function will call ``initialize()`` on it. If ``None``, a
+            ``connection`` must be provided and a temporary session will be
+            created automatically.
+        connection: Connection config to create a new session if ``session`` is
+            ``None``.
+        callbacks: Optional ``Callbacks`` for handling notifications and events.
+        server_name: Name of the server (used for callback context).
+
+    Returns:
+        The ``InitializeResult`` from the MCP server, containing:
+            - ``instructions``: Optional server instructions for the LLM.
+            - ``serverInfo``: Server implementation details (name, version).
+            - ``capabilities``: Server capabilities.
+            - ``protocolVersion``: MCP protocol version.
+
+    Raises:
+        ValueError: If neither ``session`` nor ``connection`` is provided.
+
+    """
+    if session is not None:
+        return await session.initialize()
+
+    if connection is None:
+        msg = "Either a session or a connection config must be provided"
+        raise ValueError(msg)
+
+    mcp_callbacks = (
+        callbacks.to_mcp_format(context=CallbackContext(server_name=server_name))
+        if callbacks is not None
+        else _MCPCallbacks()
+    )
+
+    async with create_session(
+        connection, mcp_callbacks=mcp_callbacks
+    ) as new_session:
+        return await new_session.initialize()

--- a/langchain_mcp_adapters/server_info.py
+++ b/langchain_mcp_adapters/server_info.py
@@ -11,9 +11,19 @@ from mcp.types import InitializeResult
 from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks, _MCPCallbacks
 from langchain_mcp_adapters.sessions import Connection, create_session
 
+ALREADY_INITIALIZED_ERROR = (
+    "The provided ClientSession has already been initialized. "
+    "load_mcp_server_info() performs the initialize handshake itself, so it needs a "
+    "session that has not been initialized yet; re-initializing a live session "
+    "violates the MCP protocol, resets the server's initialization state, and can "
+    "cause concurrent requests on that session to fail. Either pass an uninitialized "
+    "session (e.g. MultiServerMCPClient.session(name, auto_initialize=False)), or "
+    "omit `session` and pass `connection` to have a temporary session created."
+)
+
 
 async def load_mcp_server_info(
-    session: ClientSession | None = None,
+    session: ClientSession | None,
     *,
     connection: Connection | None = None,
     callbacks: Callbacks | None = None,
@@ -25,28 +35,53 @@ async def load_mcp_server_info(
     server instructions, capabilities, implementation details, and protocol
     version.
 
+    !!! note
+
+        Unlike [`load_mcp_tools`][langchain_mcp_adapters.tools.load_mcp_tools],
+        [`load_mcp_prompt`][langchain_mcp_adapters.prompts.load_mcp_prompt] and
+        [`load_mcp_resources`][langchain_mcp_adapters.resources.load_mcp_resources],
+        which expect an already-initialized session, this function performs the
+        `initialize()` handshake itself and therefore requires a session that has
+        *not* been initialized yet. `MultiServerMCPClient.session()` initializes
+        by default, so pass `auto_initialize=False` when obtaining a session for
+        this function. Passing an already-initialized session raises `ValueError`
+        rather than re-running the handshake.
+
+        There is no way to recover an `InitializeResult` from a session that is
+        already initialized: the MCP SDK caches only `capabilities` and discards
+        `instructions`, `serverInfo` and `protocolVersion`.
+
     Args:
-        session: An **uninitialized** MCP client session. If provided, this
-            function will call `initialize()` on it. If `None`, a
+        session: An MCP client session that has **not** been initialized yet.
+            If provided, this function calls `initialize()` on it. If `None`, a
             `connection` must be provided and a temporary session will be
             created automatically.
         connection: Connection config to create a new session if `session` is
             `None`.
         callbacks: Optional `Callbacks` for handling notifications and events.
-        server_name: Name of the server (used for callback context).
+            Only applied to sessions created from `connection`; ignored when
+            `session` is provided, since the caller owns that session's
+            callbacks.
+        server_name: Name of the server, used for callback context. Ignored when
+            `session` is provided, for the same reason as `callbacks`.
 
     Returns:
-        The `InitializeResult` from the MCP server, containing:
-            - `instructions`: Optional server instructions for the LLM.
-            - `serverInfo`: Server implementation details (name, version).
-            - `capabilities`: Server capabilities.
-            - `protocolVersion`: MCP protocol version.
+        The `InitializeResult` from the MCP server. Most callers want
+            `.instructions` and `.serverInfo`; see `mcp.types.InitializeResult`
+            for the full field set, which servers may extend with additional
+            fields.
 
     Raises:
-        ValueError: If neither `session` nor `connection` is provided.
+        ValueError: If neither `session` nor `connection` is provided, if
+            `session` has already been initialized, or if `connection` is
+            missing `transport` or the parameters required by its transport.
+        RuntimeError: If the server negotiates an unsupported MCP protocol
+            version, or if the session closes without completing the handshake.
 
     """
     if session is not None:
+        if session.get_server_capabilities() is not None:
+            raise ValueError(ALREADY_INITIALIZED_ERROR)
         return await session.initialize()
 
     if connection is None:
@@ -59,7 +94,30 @@ async def load_mcp_server_info(
         else _MCPCallbacks()
     )
 
-    async with create_session(
-        connection, mcp_callbacks=mcp_callbacks
-    ) as new_session:
-        return await new_session.initialize()
+    result: InitializeResult | None = None
+    captured_exception: BaseException | None = None
+    async with create_session(connection, mcp_callbacks=mcp_callbacks) as new_session:
+        try:
+            result = await new_session.initialize()
+        except Exception as e:  # noqa: BLE001
+            # Capture the exception to re-raise outside the context manager, which
+            # may otherwise suppress it. Mirrors the work-around in `tools.py` for
+            # an MCP SDK issue that swallows exceptions on client disconnect.
+            captured_exception = e
+
+    if captured_exception is not None:
+        raise captured_exception
+
+    if result is None:
+        # Reachable only if the context manager suppressed an exception without
+        # `initialize()` returning, which would otherwise return `None` in
+        # violation of this function's return type.
+        msg = (
+            f"The MCP initialize handshake with server '{server_name or connection}' "
+            "produced no result and raised no error; the session was closed by the "
+            "transport. Check that the server is running and speaking MCP on the "
+            "configured endpoint."
+        )
+        raise RuntimeError(msg)
+
+    return result

--- a/langchain_mcp_adapters/server_info.py
+++ b/langchain_mcp_adapters/server_info.py
@@ -113,7 +113,7 @@ async def load_mcp_server_info(
         # `initialize()` returning, which would otherwise return `None` in
         # violation of this function's return type.
         msg = (
-            f"The MCP initialize handshake with server '{server_name or connection}' "
+            f"The MCP initialize handshake with server '{server_name or '[unknown server]'}' "
             "produced no result and raised no error; the session was closed by the "
             "transport. Check that the server is running and speaking MCP on the "
             "configured endpoint."

--- a/langchain_mcp_adapters/server_info.py
+++ b/langchain_mcp_adapters/server_info.py
@@ -27,23 +27,23 @@ async def load_mcp_server_info(
 
     Args:
         session: An **uninitialized** MCP client session. If provided, this
-            function will call ``initialize()`` on it. If ``None``, a
-            ``connection`` must be provided and a temporary session will be
+            function will call `initialize()` on it. If `None`, a
+            `connection` must be provided and a temporary session will be
             created automatically.
-        connection: Connection config to create a new session if ``session`` is
-            ``None``.
-        callbacks: Optional ``Callbacks`` for handling notifications and events.
+        connection: Connection config to create a new session if `session` is
+            `None`.
+        callbacks: Optional `Callbacks` for handling notifications and events.
         server_name: Name of the server (used for callback context).
 
     Returns:
-        The ``InitializeResult`` from the MCP server, containing:
-            - ``instructions``: Optional server instructions for the LLM.
-            - ``serverInfo``: Server implementation details (name, version).
-            - ``capabilities``: Server capabilities.
-            - ``protocolVersion``: MCP protocol version.
+        The `InitializeResult` from the MCP server, containing:
+            - `instructions`: Optional server instructions for the LLM.
+            - `serverInfo`: Server implementation details (name, version).
+            - `capabilities`: Server capabilities.
+            - `protocolVersion`: MCP protocol version.
 
     Raises:
-        ValueError: If neither ``session`` nor ``connection`` is provided.
+        ValueError: If neither `session` nor `connection` is provided.
 
     """
     if session is not None:

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -3,7 +3,10 @@ def test_import() -> None:
     from langchain_mcp_adapters import (  # noqa: F401, PLC0415
         callbacks,
         client,
+        interceptors,
         prompts,
         resources,
+        server_info,
+        sessions,
         tools,
     )

--- a/tests/test_server_info.py
+++ b/tests/test_server_info.py
@@ -1,0 +1,113 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from mcp.server import FastMCP
+from mcp.types import InitializeResult
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.server_info import load_mcp_server_info
+from tests.utils import run_streamable_http
+
+
+def _create_server_with_instructions():
+    server = FastMCP(
+        "test-server",
+        instructions="Use this server for testing purposes only.",
+        port=8187,
+    )
+
+    @server.tool()
+    def ping() -> str:
+        """Ping the server."""
+        return "pong"
+
+    return server
+
+
+def _create_server_without_instructions():
+    server = FastMCP("no-instructions-server", port=8188)
+
+    @server.tool()
+    def ping() -> str:
+        """Ping the server."""
+        return "pong"
+
+    return server
+
+
+async def test_load_mcp_server_info_with_connection(socket_enabled) -> None:
+    """Test loading server info using a connection config."""
+    with run_streamable_http(_create_server_with_instructions, 8187):
+        result = await load_mcp_server_info(
+            connection={
+                "url": "http://localhost:8187/mcp",
+                "transport": "streamable_http",
+            },
+        )
+        assert isinstance(result, InitializeResult)
+        assert result.instructions == "Use this server for testing purposes only."
+        assert result.serverInfo.name == "test-server"
+
+
+async def test_load_mcp_server_info_no_instructions(socket_enabled) -> None:
+    """Test loading server info when server has no instructions."""
+    with run_streamable_http(_create_server_without_instructions, 8188):
+        result = await load_mcp_server_info(
+            connection={
+                "url": "http://localhost:8188/mcp",
+                "transport": "streamable_http",
+            },
+        )
+        assert isinstance(result, InitializeResult)
+        assert result.instructions is None
+
+
+async def test_load_mcp_server_info_with_session() -> None:
+    """Test loading server info with an uninitialized session."""
+    mock_result = InitializeResult(
+        protocolVersion="2025-03-26",
+        capabilities={},
+        serverInfo={"name": "mock-server", "version": "1.0"},
+        instructions="Mock instructions",
+    )
+    session = AsyncMock()
+    session.initialize.return_value = mock_result
+
+    result = await load_mcp_server_info(session)
+
+    session.initialize.assert_called_once()
+    assert result.instructions == "Mock instructions"
+    assert result.serverInfo.name == "mock-server"
+
+
+async def test_load_mcp_server_info_raises_without_args() -> None:
+    """Test that ValueError is raised when neither session nor connection."""
+    with pytest.raises(ValueError, match="Either a session or a connection"):
+        await load_mcp_server_info()
+
+
+async def test_client_get_server_info(socket_enabled) -> None:
+    """Test MultiServerMCPClient.get_server_info returns info for all servers."""
+    with (
+        run_streamable_http(_create_server_with_instructions, 8187),
+        run_streamable_http(_create_server_without_instructions, 8188),
+    ):
+        client = MultiServerMCPClient(
+            {
+                "with_instructions": {
+                    "url": "http://localhost:8187/mcp",
+                    "transport": "streamable_http",
+                },
+                "without_instructions": {
+                    "url": "http://localhost:8188/mcp",
+                    "transport": "streamable_http",
+                },
+            },
+        )
+        info = await client.get_info()
+        assert len(info) == 2
+        assert info["with_instructions"].instructions == (
+            "Use this server for testing purposes only."
+        )
+        assert info["with_instructions"].serverInfo.name == "test-server"
+        assert info["without_instructions"].instructions is None

--- a/tests/test_server_info.py
+++ b/tests/test_server_info.py
@@ -1,12 +1,26 @@
+import contextlib
+import os
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
+from mcp import ClientSession
 from mcp.server import FastMCP
-from mcp.types import InitializeResult
+from mcp.types import (
+    LATEST_PROTOCOL_VERSION,
+    InitializeResult,
+    LoggingMessageNotificationParams,
+    ServerCapabilities,
+)
 
+from langchain_mcp_adapters import server_info as server_info_module
+from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.server_info import load_mcp_server_info
 from tests.utils import run_streamable_http
+
+# A port nothing listens on, used to exercise unreachable-server handling.
+CLOSED_PORT = 8189
 
 
 def _create_server_with_instructions():
@@ -35,10 +49,20 @@ def _create_server_without_instructions():
     return server
 
 
+def _mock_initialize_result() -> InitializeResult:
+    return InitializeResult(
+        protocolVersion=LATEST_PROTOCOL_VERSION,
+        capabilities={},
+        serverInfo={"name": "mock-server", "version": "1.0"},
+        instructions="Mock instructions",
+    )
+
+
 async def test_load_mcp_server_info_with_connection(socket_enabled) -> None:
     """Test loading server info using a connection config."""
     with run_streamable_http(_create_server_with_instructions, 8187):
         result = await load_mcp_server_info(
+            None,
             connection={
                 "url": "http://localhost:8187/mcp",
                 "transport": "streamable_http",
@@ -47,12 +71,33 @@ async def test_load_mcp_server_info_with_connection(socket_enabled) -> None:
         assert isinstance(result, InitializeResult)
         assert result.instructions == "Use this server for testing purposes only."
         assert result.serverInfo.name == "test-server"
+        # The server registers a `ping` tool, so it must advertise tool support.
+        assert result.capabilities.tools is not None
+        assert result.protocolVersion
+
+
+async def test_load_mcp_server_info_over_stdio() -> None:
+    """Test loading server info over the stdio transport."""
+    math_server_path = os.path.join(Path(__file__).parent, "servers/math_server.py")
+
+    result = await load_mcp_server_info(
+        None,
+        connection={
+            "command": "python3",
+            "args": [math_server_path],
+            "transport": "stdio",
+        },
+    )
+    assert isinstance(result, InitializeResult)
+    assert result.serverInfo.name == "Math"
+    assert result.capabilities.tools is not None
 
 
 async def test_load_mcp_server_info_no_instructions(socket_enabled) -> None:
     """Test loading server info when server has no instructions."""
     with run_streamable_http(_create_server_without_instructions, 8188):
         result = await load_mcp_server_info(
+            None,
             connection={
                 "url": "http://localhost:8188/mcp",
                 "transport": "streamable_http",
@@ -60,17 +105,17 @@ async def test_load_mcp_server_info_no_instructions(socket_enabled) -> None:
         )
         assert isinstance(result, InitializeResult)
         assert result.instructions is None
+        assert result.serverInfo.name == "no-instructions-server"
 
 
 async def test_load_mcp_server_info_with_session() -> None:
-    """Test loading server info with an uninitialized session."""
-    mock_result = InitializeResult(
-        protocolVersion="2025-03-26",
-        capabilities={},
-        serverInfo={"name": "mock-server", "version": "1.0"},
-        instructions="Mock instructions",
-    )
-    session = AsyncMock()
+    """Test that a provided session is initialized and its result returned."""
+    mock_result = _mock_initialize_result()
+    # `spec` keeps sync methods (`get_server_capabilities`) sync and async ones
+    # (`initialize`) async, matching the real `ClientSession`.
+    session = AsyncMock(spec=ClientSession)
+    # `None` capabilities means the session has not been initialized yet.
+    session.get_server_capabilities.return_value = None
     session.initialize.return_value = mock_result
 
     result = await load_mcp_server_info(session)
@@ -80,10 +125,89 @@ async def test_load_mcp_server_info_with_session() -> None:
     assert result.serverInfo.name == "mock-server"
 
 
+async def test_load_mcp_server_info_rejects_initialized_session() -> None:
+    """Test that an already-initialized session is rejected, not re-initialized."""
+    session = AsyncMock(spec=ClientSession)
+    session.get_server_capabilities.return_value = ServerCapabilities()
+
+    with pytest.raises(ValueError, match="already been initialized"):
+        await load_mcp_server_info(session)
+
+    session.initialize.assert_not_called()
+
+
+async def test_load_mcp_server_info_rejects_initialized_real_session(
+    socket_enabled,
+) -> None:
+    """Test the initialized-session guard on a real session, and the escape hatch."""
+    with run_streamable_http(_create_server_with_instructions, 8187):
+        client = MultiServerMCPClient(
+            {
+                "with_instructions": {
+                    "url": "http://localhost:8187/mcp",
+                    "transport": "streamable_http",
+                },
+            },
+        )
+
+        # `session()` initializes by default, so it must be rejected.
+        async with client.session("with_instructions") as session:
+            with pytest.raises(ValueError, match="already been initialized"):
+                await load_mcp_server_info(session)
+
+        # `auto_initialize=False` is the documented way to use the session path.
+        async with client.session(
+            "with_instructions", auto_initialize=False
+        ) as session:
+            result = await load_mcp_server_info(session)
+            assert result.serverInfo.name == "test-server"
+            # The session is usable afterwards, since it is now initialized.
+            tools = await session.list_tools()
+            assert [tool.name for tool in tools.tools] == ["ping"]
+
+
 async def test_load_mcp_server_info_raises_without_args() -> None:
-    """Test that ValueError is raised when neither session nor connection."""
+    """Test that ValueError is raised when neither session nor connection is given."""
     with pytest.raises(ValueError, match="Either a session or a connection"):
-        await load_mcp_server_info()
+        await load_mcp_server_info(None)
+
+
+async def test_load_mcp_server_info_passes_server_name_to_callbacks(
+    monkeypatch,
+) -> None:
+    """Test that server_name reaches the CallbackContext handed to callbacks."""
+    contexts: list[CallbackContext] = []
+
+    async def logging_callback(params, context) -> None:
+        contexts.append(context)
+
+    captured = {}
+
+    @contextlib.asynccontextmanager
+    async def fake_create_session(connection, *, mcp_callbacks=None):
+        captured["mcp_callbacks"] = mcp_callbacks
+        session = AsyncMock()
+        session.initialize.return_value = _mock_initialize_result()
+        yield session
+
+    monkeypatch.setattr(server_info_module, "create_session", fake_create_session)
+
+    await load_mcp_server_info(
+        None,
+        connection={
+            "url": "http://localhost:8187/mcp",
+            "transport": "streamable_http",
+        },
+        callbacks=Callbacks(on_logging_message=logging_callback),
+        server_name="my_server",
+    )
+
+    mcp_callbacks = captured["mcp_callbacks"]
+    assert mcp_callbacks.logging_callback is not None
+    await mcp_callbacks.logging_callback(
+        LoggingMessageNotificationParams(level="info", data="hello")
+    )
+    assert [context.server_name for context in contexts] == ["my_server"]
 
 
 async def test_client_get_server_info(socket_enabled) -> None:
@@ -104,10 +228,75 @@ async def test_client_get_server_info(socket_enabled) -> None:
                 },
             },
         )
-        info = await client.get_info()
+        info = await client.get_server_info()
         assert len(info) == 2
         assert info["with_instructions"].instructions == (
             "Use this server for testing purposes only."
         )
         assert info["with_instructions"].serverInfo.name == "test-server"
         assert info["without_instructions"].instructions is None
+        assert info["without_instructions"].serverInfo.name == "no-instructions-server"
+
+
+async def test_client_get_server_info_single_server(socket_enabled) -> None:
+    """Test that server_name scopes get_server_info to one server."""
+    with run_streamable_http(_create_server_with_instructions, 8187):
+        client = MultiServerMCPClient(
+            {
+                "with_instructions": {
+                    "url": "http://localhost:8187/mcp",
+                    "transport": "streamable_http",
+                },
+                # Unreachable, but must not be queried when scoping by name.
+                "unreachable": {
+                    "url": f"http://localhost:{CLOSED_PORT}/mcp",
+                    "transport": "streamable_http",
+                },
+            },
+        )
+        info = await client.get_server_info(server_name="with_instructions")
+        assert list(info) == ["with_instructions"]
+        assert info["with_instructions"].serverInfo.name == "test-server"
+
+
+async def test_client_get_server_info_unknown_server() -> None:
+    """Test that an unknown server_name raises ValueError."""
+    client = MultiServerMCPClient(
+        {
+            "with_instructions": {
+                "url": "http://localhost:8187/mcp",
+                "transport": "streamable_http",
+            },
+        },
+    )
+    with pytest.raises(ValueError, match="Couldn't find a server with name 'nope'"):
+        await client.get_server_info(server_name="nope")
+
+
+async def test_client_get_server_info_no_connections() -> None:
+    """Test that get_server_info returns an empty dict with no connections."""
+    assert await MultiServerMCPClient().get_server_info() == {}
+
+
+async def test_client_get_server_info_names_failing_server(socket_enabled) -> None:
+    """Test that a failing server is named in the error, and healthy ones aren't."""
+    with run_streamable_http(_create_server_with_instructions, 8187):
+        client = MultiServerMCPClient(
+            {
+                "with_instructions": {
+                    "url": "http://localhost:8187/mcp",
+                    "transport": "streamable_http",
+                },
+                "unreachable": {
+                    "url": f"http://localhost:{CLOSED_PORT}/mcp",
+                    "transport": "streamable_http",
+                },
+            },
+        )
+        with pytest.raises(RuntimeError, match="'unreachable'") as exc_info:
+            await client.get_server_info()
+
+        message = str(exc_info.value)
+        assert "1 of 2" in message
+        # The healthy server must not be blamed for the failure.
+        assert "'with_instructions'" not in message


### PR DESCRIPTION
Closes #405

MCP servers can return useful metadata during the initialize handshake: optional `instructions` for how an agent should use the server, capability flags, protocol version, and implementation details like server name/version. Until now, `langchain-mcp-adapters` discarded that `InitializeResult` after connecting, so apps could load tools, prompts, and resources, but had no first-class way to read the rest of the server metadata.

This change exposes that handshake result:

- `load_mcp_server_info()` returns the full MCP `InitializeResult` from either an uninitialized session or a connection config
- `MultiServerMCPClient.get_server_info()` queries configured servers in parallel and returns a `{server_name: InitializeResult}` map
- Passing `server_name` scopes the client call to one server; omitting it queries every configured connection

That lets you inject server-provided instructions into an agent system prompt, inspect capabilities before calling tools, or surface server name/version info for debugging and routing.

```python
from langchain_mcp_adapters.client import MultiServerMCPClient

client = MultiServerMCPClient(
    {
        "math": {
            "command": "python",
            "args": ["/path/to/math_server.py"],
            "transport": "stdio",
        },
    }
)

info = await client.get_server_info()
print(info["math"].instructions)
print(info["math"].serverInfo.name)
print(info["math"].capabilities)
```

If a server does not advertise instructions, `instructions` is `None`.

`get_server_info()` creates a fresh temporary session for each queried server on every call and does not cache results. If any server fails, every server is still queried, and the raised error names each failing server rather than returning partial results.

`load_mcp_server_info()` performs the initialize handshake itself, so it needs a session that has not been initialized yet (for example `client.session(name, auto_initialize=False)`). Passing an already-initialized session raises `ValueError` instead of re-running the handshake on a live session.
