### PR TITLE
feat(examples): add agentpay-mcp example — x402 payments for LangGraph agents

### DIFF
--- a/examples/servers/agentpay_payments/README.md
+++ b/examples/servers/agentpay_payments/README.md
@@ -1,0 +1,44 @@
+# agentpay-mcp Example — x402 Payments for LangGraph Agents
+
+LangGraph agents can call x402-protected API endpoints and pay automatically,
+with no custom payment handling code in the agent.
+
+[agentpay-mcp](https://www.npmjs.com/package/agentpay-mcp) runs as an MCP
+subprocess. The agent gets a `pay_x402_endpoint` tool — when it hits a 402,
+it calls the tool, signs the USDC transfer, and retries. The agent framework
+never needs to know about payment mechanics.
+
+## Setup
+
+```bash
+pip install langchain-mcp-adapters langgraph langchain-anthropic
+npm install -g agentpay-mcp
+```
+
+```bash
+export AGENT_PRIVATE_KEY=0x...       # Agent hot wallet key
+export AGENT_WALLET_ADDRESS=0x...    # Deployed AgentAccountV2 address
+export CHAIN_ID=84532                # 84532 = Base Sepolia testnet
+export ANTHROPIC_API_KEY=...
+```
+
+## Run
+
+```bash
+python agentpay_example.py
+```
+
+## How it works
+
+agentpay-mcp wraps [agentwallet-sdk](https://www.npmjs.com/package/agentwallet-sdk)
+behind an MCP interface. On-chain spend limits (set when deploying the wallet)
+cap what the agent can pay per transaction and per day — operators configure
+this before handing keys to an agent.
+
+No browser. No wallet extension. Fully server-side.
+
+## Tested with
+
+- langchain-mcp-adapters 0.1.x
+- agentpay-mcp 1.2.0
+- Base Sepolia testnet

--- a/examples/servers/agentpay_payments/agentpay_example.py
+++ b/examples/servers/agentpay_payments/agentpay_example.py
@@ -1,0 +1,69 @@
+"""
+x402 payments for LangGraph agents via agentpay-mcp
+
+Any LangGraph agent can pay for x402-protected API endpoints automatically.
+agentpay-mcp handles the 402 detect -> sign -> retry loop — no custom
+payment code needed in the agent.
+
+Setup:
+    pip install langchain-mcp-adapters langgraph langchain-anthropic
+    npm install -g agentpay-mcp
+
+    export AGENT_PRIVATE_KEY=0x...
+    export AGENT_WALLET_ADDRESS=0x...
+    export ANTHROPIC_API_KEY=...
+"""
+
+import asyncio
+import os
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+from langchain_anthropic import ChatAnthropic
+
+
+async def main():
+    # Connect agentpay-mcp as an MCP server — runs as a subprocess, no browser
+    client = MultiServerMCPClient(
+        {
+            "payments": {
+                "command": "npx",
+                "args": ["agentpay-mcp"],
+                "env": {
+                    "AGENT_PRIVATE_KEY": os.environ["AGENT_PRIVATE_KEY"],
+                    "AGENT_WALLET_ADDRESS": os.environ["AGENT_WALLET_ADDRESS"],
+                    # Optional: Base Sepolia testnet (84532) or mainnet (8453)
+                    "CHAIN_ID": os.environ.get("CHAIN_ID", "84532"),
+                },
+                "transport": "stdio",
+            }
+        }
+    )
+
+    tools = await client.get_tools()
+    # Agent now has pay_x402_endpoint available as a tool
+
+    model = ChatAnthropic(model="claude-3-5-haiku-latest")
+    agent = create_react_agent(model, tools)
+
+    # When the agent calls an x402-protected endpoint and gets a 402,
+    # it calls pay_x402_endpoint automatically — signs the USDC transfer,
+    # submits payment to the facilitator, retries the original request.
+    result = await agent.ainvoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Call https://api.example.com/data — it requires x402 payment. "
+                        "Use the pay_x402_endpoint tool if you get a 402 response."
+                    ),
+                }
+            ]
+        }
+    )
+
+    print(result["messages"][-1].content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What this adds

A working example showing how to add x402 payment capabilities to any LangGraph agent in ~10 lines, using [agentpay-mcp](https://www.npmjs.com/package/agentpay-mcp).

## The problem

LangGraph agents increasingly call external APIs that charge per request. x402 is the emerging HTTP standard for machine-to-machine payments — but there's no documented path for a LangGraph agent to handle a 402 response. Developers end up writing custom payment middleware from scratch.

## The solution

agentpay-mcp is an MCP server that wraps the full x402 payment loop behind a single tool call. Add it to `MultiServerMCPClient`, and the agent automatically handles 402 responses — detects the payment requirement, signs the USDC transfer, and retries:

```python
from langchain_mcp_adapters.client import MultiServerMCPClient

client = MultiServerMCPClient({
    "payments": {
        "command": "npx",
        "args": ["agentpay-mcp"],
        "env": {
            "AGENT_PRIVATE_KEY": os.environ["AGENT_PRIVATE_KEY"],
            "AGENT_WALLET_ADDRESS": os.environ["AGENT_WALLET_ADDRESS"],
        },
        "transport": "stdio",
    }
})

tools = await client.get_tools()
# agent now has pay_x402_endpoint available
```

No browser wallet. No human in the loop. Works with any LangGraph agent.

## Files added

- `examples/servers/agentpay_payments/agentpay_example.py` — full working example
- `examples/servers/agentpay_payments/README.md` — setup and usage docs

## Tested with

- langchain-mcp-adapters 0.1.x
- agentpay-mcp 1.2.0 (npm: [agentpay-mcp](https://www.npmjs.com/package/agentpay-mcp), MIT)
- Base Sepolia testnet