### PR TITLE
feat: support disabling MCP tools per server

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,35 @@ weather_response = await agent.ainvoke({"messages": "what is the weather in nyc?
 >     tools = await load_mcp_tools(session)
 > ```
 
+### Disabling specific tools per server
+
+If an MCP server exposes tools you do not want to bind into LangChain, add
+`disabled_tools` to that server's connection config. Tool names are matched
+against the original MCP tool name before `tool_name_prefix` is applied.
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+client = MultiServerMCPClient(
+    {
+        "tikhub-tiktok": {
+            "transport": "http",
+            "url": "https://mcp.tikhub.io/tiktok/mcp",
+            "headers": {
+                "Authorization": "Bearer YOUR_API_KEY",
+            },
+            "disabled_tools": [
+                "xiaohongshu_web_v2_fetch_search_notes",
+                "xiaohongshu_web_get_home_recommend",
+                "xiaohongshu_web_get_note_info_v2",
+            ],
+        },
+    }
+)
+
+tools = await client.get_tools()
+```
+
 ## Streamable HTTP
 
 MCP now supports [streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport.

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -60,7 +60,9 @@ class MultiServerMCPClient:
 
         Args:
             connections: A `dict` mapping server names to connection configurations. If
-                `None`, no initial connections are established.
+                `None`, no initial connections are established. Each server
+                configuration may also include `disabled_tools` to exclude
+                specific MCP tool names when loading LangChain tools.
             callbacks: Optional callbacks for handling notifications and events.
             tool_interceptors: Optional list of tool call interceptors for modifying
                 requests and responses.
@@ -171,6 +173,7 @@ class MultiServerMCPClient:
                     f"expected one of '{list(self.connections.keys())}'"
                 )
                 raise ValueError(msg)
+            disabled_tools = self.connections[server_name].get("disabled_tools")
             return await load_mcp_tools(
                 None,
                 connection=self.connections[server_name],
@@ -178,11 +181,13 @@ class MultiServerMCPClient:
                 server_name=server_name,
                 tool_interceptors=self.tool_interceptors,
                 tool_name_prefix=self.tool_name_prefix,
+                disabled_tools=disabled_tools,
             )
 
         all_tools: list[BaseTool] = []
         load_mcp_tool_tasks = []
         for name, connection in self.connections.items():
+            disabled_tools = connection.get("disabled_tools")
             load_mcp_tool_task = asyncio.create_task(
                 load_mcp_tools(
                     None,
@@ -191,6 +196,7 @@ class MultiServerMCPClient:
                     server_name=name,
                     tool_interceptors=self.tool_interceptors,
                     tool_name_prefix=self.tool_name_prefix,
+                    disabled_tools=disabled_tools,
                 )
             )
             load_mcp_tool_tasks.append(load_mcp_tool_task)

--- a/langchain_mcp_adapters/sessions.py
+++ b/langchain_mcp_adapters/sessions.py
@@ -58,7 +58,14 @@ class McpHttpClientFactory(Protocol):
         ...
 
 
-class StdioConnection(TypedDict):
+class BaseConnection(TypedDict, total=False):
+    """Shared configuration options for MCP server connections."""
+
+    disabled_tools: list[str]
+    """Tool names to exclude when loading LangChain tools for this server."""
+
+
+class StdioConnection(BaseConnection):
     """Configuration for stdio transport connections to MCP servers."""
 
     transport: Literal["stdio"]
@@ -105,7 +112,7 @@ class StdioConnection(TypedDict):
     """Additional keyword arguments to pass to the ClientSession."""
 
 
-class SSEConnection(TypedDict):
+class SSEConnection(BaseConnection):
     """Configuration for Server-Sent Events (SSE) transport connections to MCP."""
 
     transport: Literal["sse"]
@@ -140,7 +147,7 @@ class SSEConnection(TypedDict):
     """Optional authentication for the HTTP client."""
 
 
-class StreamableHttpConnection(TypedDict):
+class StreamableHttpConnection(BaseConnection):
     """Connection configuration for Streamable HTTP transport."""
 
     transport: Literal["streamable_http"]
@@ -171,7 +178,7 @@ class StreamableHttpConnection(TypedDict):
     """Optional authentication for the HTTP client."""
 
 
-class WebsocketConnection(TypedDict):
+class WebsocketConnection(BaseConnection):
     """Configuration for WebSocket transport connections to MCP servers."""
 
     transport: Literal["websocket"]
@@ -384,7 +391,11 @@ async def create_session(
         raise ValueError(msg)
 
     transport = connection["transport"]
-    params = {k: v for k, v in connection.items() if k != "transport"}
+    params = {
+        k: v
+        for k, v in connection.items()
+        if k not in {"transport", "disabled_tools"}
+    }
 
     if mcp_callbacks is not None:
         params["session_kwargs"] = params.get("session_kwargs", {})

--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -4,7 +4,7 @@ This module provides functionality to convert MCP tools into LangChain-compatibl
 tools, handle tool execution, and manage tool conversion between the two formats.
 """
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Annotated, Any, TypedDict, get_args
 
 from langchain_core.messages import ToolMessage
@@ -303,7 +303,7 @@ def convert_mcp_tool_to_langchain_tool(
         raise ValueError(msg)
 
     async def call_tool(
-        runtime: Annotated[Any, InjectedToolArg()] = None,
+        runtime: Annotated[object | None, InjectedToolArg()] = None,
         **arguments: dict[str, Any],
     ) -> tuple[ConvertedToolResult, MCPToolArtifact | None]:
         """Execute tool call with interceptor chain and return formatted result.
@@ -441,6 +441,7 @@ async def load_mcp_tools(
     tool_interceptors: list[ToolCallInterceptor] | None = None,
     server_name: str | None = None,
     tool_name_prefix: bool = False,
+    disabled_tools: Sequence[str] | None = None,
 ) -> list[BaseTool]:
     """Load all available MCP tools and convert them to LangChain [tools](https://docs.langchain.com/oss/python/langchain/tools).
 
@@ -452,6 +453,8 @@ async def load_mcp_tools(
         server_name: Name of the server these tools belong to.
         tool_name_prefix: If `True` and `server_name` is provided, tool names will be
             prefixed w/ server name (e.g., `"weather_search"` instead of `"search"`).
+        disabled_tools: Optional iterable of MCP tool names to exclude before
+            converting them to LangChain tools.
 
     Returns:
         List of LangChain [tools](https://docs.langchain.com/oss/python/langchain/tools).
@@ -463,6 +466,9 @@ async def load_mcp_tools(
     if session is None and connection is None:
         msg = "Either a session or a connection config must be provided"
         raise ValueError(msg)
+
+    if disabled_tools is None and connection is not None:
+        disabled_tools = connection.get("disabled_tools")
 
     mcp_callbacks = (
         callbacks.to_mcp_format(context=CallbackContext(server_name=server_name))
@@ -482,6 +488,10 @@ async def load_mcp_tools(
             tools = await _list_all_tools(tool_session)
     else:
         tools = await _list_all_tools(session)
+
+    if disabled_tools:
+        disabled_tool_names = set(disabled_tools)
+        tools = [tool for tool in tools if tool.name not in disabled_tool_names]
 
     return [
         convert_mcp_tool_to_langchain_tool(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -140,6 +140,81 @@ async def test_multi_server_connect_methods(
     assert tool_names == {"add", "multiply", "get_time"}
 
 
+async def test_get_tools_respects_disabled_tools():
+    """Test that disabled_tools filters tool loading for a specific server."""
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+    weather_server_path = os.path.join(current_dir, "servers/weather_server.py")
+
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+                "disabled_tools": ["multiply"],
+            },
+            "weather": {
+                "command": "python3",
+                "args": [weather_server_path],
+                "transport": "stdio",
+            },
+        },
+    )
+
+    all_tools = await client.get_tools()
+    assert {tool.name for tool in all_tools} == {"add", "get_weather"}
+
+    math_tools = await client.get_tools(server_name="math")
+    assert [tool.name for tool in math_tools] == ["add"]
+
+    add_tool = math_tools[0]
+    result = await add_tool.ainvoke({"a": 7, "b": 8})
+    assert result == [{"type": "text", "text": "15", "id": IsLangChainID}]
+
+
+async def test_session_allows_disabled_tools_in_connection_config():
+    """Test that disabled_tools does not break raw session creation."""
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+                "disabled_tools": ["multiply"],
+            }
+        },
+    )
+
+    async with client.session("math") as session:
+        tools = await load_mcp_tools(session)
+
+    assert {tool.name for tool in tools} == {"add", "multiply"}
+
+
+async def test_get_tools_returns_empty_list_when_all_tools_disabled():
+    """Test that disabling every tool for a server returns an empty list."""
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+                "disabled_tools": ["add", "multiply"],
+            }
+        },
+    )
+
+    tools = await client.get_tools(server_name="math")
+    assert tools == []
+
+
 async def test_get_prompt():
     """Test retrieving prompts from MCP servers."""
     # Get the absolute path to the server scripts

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1177,3 +1177,49 @@ async def test_get_tools_with_name_conflict(socket_enabled) -> None:
         assert len(tools) == 2
         tool_names = {t.name for t in tools}
         assert tool_names == {"weather_search", "flights_search"}
+
+
+async def test_load_mcp_tools_respects_disabled_tools_from_connection(
+    socket_enabled,
+) -> None:
+    """Test that load_mcp_tools filters tools using connection.disabled_tools."""
+    with run_streamable_http(_create_weather_search_server, 8185):
+        tools = await load_mcp_tools(
+            None,
+            connection={
+                "url": "http://localhost:8185/mcp",
+                "transport": "streamable_http",
+                "disabled_tools": ["search"],
+            },
+        )
+
+    assert tools == []
+
+
+async def test_get_tools_filters_before_applying_tool_name_prefix(
+    socket_enabled,
+) -> None:
+    """Test that disabled_tools matches the original MCP tool name."""
+    with (
+        run_streamable_http(_create_weather_search_server, 8185),
+        run_streamable_http(_create_flights_search_server, 8186),
+    ):
+        client = MultiServerMCPClient(
+            {
+                "weather": {
+                    "url": "http://localhost:8185/mcp",
+                    "transport": "streamable_http",
+                    "disabled_tools": ["search"],
+                },
+                "flights": {
+                    "url": "http://localhost:8186/mcp",
+                    "transport": "streamable_http",
+                },
+            },
+            tool_name_prefix=True,
+        )
+
+        tools = await client.get_tools()
+
+    assert len(tools) == 1
+    assert tools[0].name == "flights_search"


### PR DESCRIPTION
## Summary

Adds support for `disabled_tools` in `MultiServerMCPClient` server configs so specific MCP tools can be excluded when loading LangChain tools.

## Changes

- add optional `disabled_tools: list[str]` to per-server connection configs
- filter tools by exact MCP tool name before applying `tool_name_prefix`
- strip `disabled_tools` before passing connection params to session creation
- document the new config option in the README
- add tests for:
  - per-server filtering
  - multi-server behavior
  - compatibility with `tool_name_prefix`
  - raw `client.session(...)` usage
  - empty result when all tools are disabled

## Validation

- `pytest tests/test_client.py tests/test_tools.py -q`
- `ruff check langchain_mcp_adapters/client.py langchain_mcp_adapters/sessions.py langchain_mcp_adapters/tools.py tests/test_client.py tests/test_tools.py`
