### PR TITLE
pass MCP tool annotations & metadata to LangChain StructuredTool

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -413,10 +413,16 @@ def convert_mcp_tool_to_langchain_tool(
 
         return _convert_call_tool_result(call_tool_result)
 
+    metadata: dict[str, Any] = {}
+    if tool.annotations is not None:
+        metadata["annotations"] = tool.annotations.model_dump()
+    fn_metadata = getattr(tool, "fn_metadata", None)
+    if fn_metadata is not None:
+        metadata["fn_metadata"] = fn_metadata
     meta = getattr(tool, "meta", None)
-    base = tool.annotations.model_dump() if tool.annotations is not None else {}
-    meta = {"_meta": meta} if meta is not None else {}
-    metadata = {**base, **meta} or None
+    if meta is not None:
+        metadata["_meta"] = meta
+    metadata = metadata or None
 
     # Apply server name prefix if requested
     lc_tool_name = tool.name

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -585,11 +585,13 @@ async def test_load_mcp_tools_with_annotations(socket_enabled) -> None:
         tool = tools[0]
         assert tool.name == "get_time"
         assert tool.metadata == {
-            "title": "Get Time",
-            "readOnlyHint": True,
-            "idempotentHint": False,
-            "destructiveHint": None,
-            "openWorldHint": None,
+            "annotations": {
+                "title": "Get Time",
+                "readOnlyHint": True,
+                "idempotentHint": False,
+                "destructiveHint": None,
+                "openWorldHint": None,
+            }
         }
 
 
@@ -825,11 +827,13 @@ async def test_convert_mcp_tool_metadata_variants():
     )
     lc_tool_ann = convert_mcp_tool_to_langchain_tool(session, mcp_tool_ann)
     assert lc_tool_ann.metadata == {
-        "title": "Title",
-        "readOnlyHint": True,
-        "idempotentHint": False,
-        "destructiveHint": None,
-        "openWorldHint": None,
+        "annotations": {
+            "title": "Title",
+            "readOnlyHint": True,
+            "idempotentHint": False,
+            "destructiveHint": None,
+            "openWorldHint": None,
+        }
     }
 
     mcp_tool_meta = MCPTool(
@@ -851,11 +855,13 @@ async def test_convert_mcp_tool_metadata_variants():
 
     lc_tool_both = convert_mcp_tool_to_langchain_tool(session, mcp_tool_both)
     assert lc_tool_both.metadata == {
-        "title": "Both",
-        "readOnlyHint": None,
-        "idempotentHint": None,
-        "destructiveHint": None,
-        "openWorldHint": None,
+        "annotations": {
+            "title": "Both",
+            "readOnlyHint": None,
+            "idempotentHint": None,
+            "destructiveHint": None,
+            "openWorldHint": None,
+        },
         "_meta": {"flag": True},
     }
 


### PR DESCRIPTION
Fixes: https://github.com/langchain-ai/langchain-mcp-adapters/issues/138

This PR updates `convert_mcp_tool_to_langchain_tool()` to ensure that MCP tool metadata, specifically annotations and `fn_metadata`, are properly passed through to the resulting LangChain `StructuredTool` metadata attribute.
