### PR TITLE
fix: UnboundLocalError when create_session.__aenter__ or initialize() fails

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -369,28 +369,46 @@ def convert_mcp_tool_to_langchain_tool(
                     msg = "Either session or connection must be provided"
                     raise ValueError(msg)
 
-                async with create_session(
-                    effective_connection, mcp_callbacks=mcp_callbacks
-                ) as tool_session:
-                    await tool_session.initialize()
-                    try:
-                        call_tool_result = await tool_session.call_tool(
-                            tool_name,
-                            tool_args,
-                            progress_callback=mcp_callbacks.progress_callback,
-                        )
-                    except Exception as e:  # noqa: BLE001
-                        # Capture exception to re-raise outside context manager
-                        captured_exception = e
+                try:
+                    async with create_session(
+                        effective_connection, mcp_callbacks=mcp_callbacks
+                    ) as tool_session:
+                        try:
+                            await tool_session.initialize()
+                            call_tool_result = await tool_session.call_tool(
+                                tool_name,
+                                tool_args,
+                                progress_callback=mcp_callbacks.progress_callback,
+                            )
+                        except BaseException as e:  # noqa: BLE001
+                            # Capture exception to re-raise outside context manager.
+                            # Using BaseException (not Exception) to also capture
+                            # asyncio.CancelledError and other BaseException subclasses.
+                            # The inner try/except captures failures inside the session body
+                            # before the context manager's __aexit__ can suppress them.
+                            captured_exception = e
+                except BaseException as outer_e:  # noqa: BLE001
+                    # Capture any exception from create_session.__aenter__,
+                    # create_session.__aexit__, or initialize() if not caught above.
+                    # Without this outer layer, __aenter__ failures leave
+                    # call_tool_result unbound and captured_exception as None,
+                    # causing an UnboundLocalError on the return below.
+                    if captured_exception is None:
+                        captured_exception = outer_e
 
-                # Re-raise the exception outside the context manager
-                # This is necessary because the context manager may suppress exceptions
-                # This change was introduced to work-around an issue in MCP SDK
+                # Re-raise the exception outside the context manager.
+                # This is necessary because the context manager may suppress exceptions.
+                # This change was introduced to work around an issue in the MCP SDK
                 # that may suppress exceptions when the client disconnects.
-                # If this is causing an issue, with your use case, please file an issue
+                # If this is causing an issue with your use case, please file an issue
                 # on the langchain-mcp-adapters GitHub repo.
                 if captured_exception is not None:
                     raise captured_exception
+
+                # call_tool_result is guaranteed bound here:
+                # - If any exception occurred (aenter, initialize, call_tool, or aexit),
+                #   captured_exception is set and we raised above.
+                # - If no exception occurred, the inner try block assigned call_tool_result.
             else:
                 call_tool_result = await session.call_tool(
                     tool_name,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1177,3 +1177,88 @@ async def test_get_tools_with_name_conflict(socket_enabled) -> None:
         assert len(tools) == 2
         tool_names = {t.name for t in tools}
         assert tool_names == {"weather_search", "flights_search"}
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_aenter_failure_raises_not_unbound() -> None:
+    """Regression test: UnboundLocalError when create_session.__aenter__ fails.
+
+    When session=None and create_session().__aenter__ raises (e.g. connection
+    refused, network error), the old code left call_tool_result unbound while
+    captured_exception remained None, causing UnboundLocalError on the
+    ``return call_tool_result`` line.  The fix wraps the entire ``async with``
+    in an outer try/except so the originating exception is always re-raised.
+    """
+    from unittest.mock import patch
+
+    mcp_tool = MCPTool(
+        name="test_tool",
+        description="A tool",
+        inputSchema={"type": "object", "properties": {}, "title": "Empty"},
+    )
+    connection = {
+        "transport": "streamable_http",
+        "url": "http://localhost:9999/mcp",
+    }
+    lc_tool = convert_mcp_tool_to_langchain_tool(
+        None, mcp_tool, connection=connection
+    )
+
+    aenter_error = ConnectionRefusedError("connection refused")
+
+    class _FailingCM:
+        async def __aenter__(self):
+            raise aenter_error
+
+        async def __aexit__(self, *_):
+            pass
+
+    with patch(
+        "langchain_mcp_adapters.tools.create_session", return_value=_FailingCM()
+    ):
+        with pytest.raises(ConnectionRefusedError, match="connection refused"):
+            await lc_tool.ainvoke(
+                {"args": {}, "id": "1", "type": "tool_call"}
+            )
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_initialize_failure_raises_not_unbound() -> None:
+    """Regression test: UnboundLocalError when tool_session.initialize() fails.
+
+    In the old code initialize() was called outside the inner try/except, so a
+    failure there also left call_tool_result unbound.
+    """
+    from unittest.mock import patch
+
+    mcp_tool = MCPTool(
+        name="test_tool",
+        description="A tool",
+        inputSchema={"type": "object", "properties": {}, "title": "Empty"},
+    )
+    connection = {
+        "transport": "streamable_http",
+        "url": "http://localhost:9999/mcp",
+    }
+    lc_tool = convert_mcp_tool_to_langchain_tool(
+        None, mcp_tool, connection=connection
+    )
+
+    init_error = RuntimeError("initialize failed")
+    mock_session = AsyncMock()
+    mock_session.initialize.side_effect = init_error
+
+    class _SessionCM:
+        async def __aenter__(self):
+            return mock_session
+
+        async def __aexit__(self, *_):
+            pass
+
+    with patch(
+        "langchain_mcp_adapters.tools.create_session", return_value=_SessionCM()
+    ):
+        with pytest.raises(RuntimeError, match="initialize failed"):
+            await lc_tool.ainvoke(
+                {"args": {}, "id": "1", "type": "tool_call"}
+            )


### PR DESCRIPTION
… fails

When session=None, if create_session().__aenter__ raises (e.g. connection refused, network timeout), call_tool_result is never assigned but captured_exception also stays None, so the subsequent 'return call_tool_result' raises UnboundLocalError instead of the original connection error.

The same issue occurs if tool_session.initialize() raises, because it was called outside the inner try/except block.

Fix:
- Wrap the entire 'async with create_session(...)' block in an outer try/except BaseException to capture __aenter__ and __aexit__ failures.
- Move initialize() inside the inner try/except so its exceptions are also captured and re-raised cleanly.
- Switch from Exception to BaseException so asyncio.CancelledError and KeyboardInterrupt are also propagated correctly.

Regression tests added for both failure paths.