### PR TITLE
ci: pin pypa/gh-action-pypi-publish to stable commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598 # v1.13.0
         with:
           packages-dir: ${{ inputs.working-directory }}/dist/
           verbose: true


### PR DESCRIPTION
## Summary
Pins the pypa/gh-action-pypi-publish action to a specific commit SHA instead of floating tag reference.

## Changes
- Pin `pypa/gh-action-pypi-publish` from `release/v1` → `106e0b0b` (v1.13.0)

## Rationale
Floating tag references (`release/v1`) can be unexpectedly updated, creating supply chain risk. SHA pinning ensures:
- Reproducible and auditable action versions
- Protection against accidental breaking changes from upstream releases
- Compliance with workflow permissions posture checks
- Better security posture against supply chain attacks

## Testing
- YAML validation passed
- Release workflow permissions now pass all posture checks