### PR TITLE
chore: update dependabot.yml to comply with posture checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,36 @@
 
 version: 2
 updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## Summary
Fixes Dependabot configuration to comply with langster-lint posture checks.

## Changes
- Add uv (Python) ecosystem to cover `pyproject.toml` dependencies
- Change schedule from weekly to monthly for version updates
- Add grouped updates with update-type split (major vs minor+patch) for both uv and github-actions

## Rationale
- **Ecosystem coverage**: The repo has a Python package (`pyproject.toml`) that was not covered by Dependabot. This fix ensures all dependencies are scanned and updated.
- **Schedule**: Monthly updates reduce PR noise while keeping dependencies reasonably current.
- **Grouping**: Splitting major from minor+patch updates allows reviewing breaking changes separately from safe updates, improving security posture and review quality.

## Testing
- YAML validation passed
- All Dependabot rules now pass posture checks