### PR TITLE
Fix #410: Feature Request: Pass `_meta` parameter through to MCP SDK ...

### DIFF
--- a/langchain_mcp_adapters/interceptors.py
+++ b/langchain_mcp_adapters/interceptors.py
@@ -46,6 +46,7 @@ class _MCPToolCallRequestOverrides(TypedDict, total=False):
     name: NotRequired[str]
     args: NotRequired[dict[str, Any]]
     headers: NotRequired[dict[str, Any] | None]
+    meta: NotRequired[dict[str, Any] | None]
 
 
 @dataclass
@@ -70,6 +71,7 @@ class MCPToolCallRequest:
     args: dict[str, Any]
     server_name: str  # Context: MCP server name
     headers: dict[str, Any] | None = None  # Modifiable: HTTP headers
+    meta: dict[str, Any] | None = None  # Modifiable: MCP _meta parameter
     runtime: object | None = None  # Context: LangGraph runtime (if any)
 
     def override(

--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -378,6 +378,7 @@ def convert_mcp_tool_to_langchain_tool(
                             tool_name,
                             tool_args,
                             progress_callback=mcp_callbacks.progress_callback,
+                            meta=request.meta,
                         )
                     except Exception as e:  # noqa: BLE001
                         # Capture exception to re-raise outside context manager
@@ -396,17 +397,20 @@ def convert_mcp_tool_to_langchain_tool(
                     tool_name,
                     tool_args,
                     progress_callback=mcp_callbacks.progress_callback,
+                    meta=request.meta,
                 )
 
             return call_tool_result
 
         # Build and execute the interceptor chain
         handler = _build_interceptor_chain(execute_tool, tool_interceptors)
+        meta = arguments.pop("_meta", None)
         request = MCPToolCallRequest(
             name=tool.name,
             args=arguments,
             server_name=server_name or "unknown",
             headers=None,
+            meta=meta,
             runtime=runtime,
         )
         call_tool_result = await handler(request)

--- a/tests/test_interceptors.py
+++ b/tests/test_interceptors.py
@@ -62,6 +62,63 @@ class TestInterceptorModifiesRequest:
             result = await add_tool.ainvoke({"a": 2, "b": 3})
             assert "10" in str(result)
 
+    async def test_meta_extracted_from_arguments(self, socket_enabled):
+        """Test that _meta in tool arguments is extracted into request.meta."""
+        captured_request = {}
+
+        async def capture_meta_interceptor(
+            request: MCPToolCallRequest,
+            handler,
+        ) -> CallToolResult:
+            captured_request["meta"] = request.meta
+            captured_request["args"] = request.args
+            return await handler(request)
+
+        with run_streamable_http(_create_math_server, 8202):
+            tools = await load_mcp_tools(
+                None,
+                connection={
+                    "url": "http://localhost:8202/mcp",
+                    "transport": "streamable_http",
+                },
+                tool_interceptors=[capture_meta_interceptor],
+            )
+
+            add_tool = next(tool for tool in tools if tool.name == "add")
+            result = await add_tool.ainvoke(
+                {"a": 2, "b": 3, "_meta": {"session_id": "abc123"}}
+            )
+            assert "5" in str(result)
+            assert captured_request["meta"] == {"session_id": "abc123"}
+            assert "_meta" not in captured_request["args"]
+
+    async def test_interceptor_overrides_meta(self, socket_enabled):
+        """Test that interceptor can override meta via request.override(meta=...)."""
+        captured_meta = {}
+
+        async def override_meta_interceptor(
+            request: MCPToolCallRequest,
+            handler,
+        ) -> CallToolResult:
+            modified = request.override(meta={"user_id": "current-user"})
+            captured_meta["meta"] = modified.meta
+            return await handler(modified)
+
+        with run_streamable_http(_create_math_server, 8210):
+            tools = await load_mcp_tools(
+                None,
+                connection={
+                    "url": "http://localhost:8210/mcp",
+                    "transport": "streamable_http",
+                },
+                tool_interceptors=[override_meta_interceptor],
+            )
+
+            add_tool = next(tool for tool in tools if tool.name == "add")
+            result = await add_tool.ainvoke({"a": 1, "b": 2})
+            assert "3" in str(result)
+            assert captured_meta["meta"] == {"user_id": "current-user"}
+
     async def test_interceptor_modifies_tool_name(self, socket_enabled):
         """Test that interceptor can redirect to different tool."""
 


### PR DESCRIPTION
Closes langchain-ai/langchain#40480

## Motivation

The MCP specification reserves `_meta` as a per-request metadata field, but `langchain-mcp-adapters` had no mechanism to pass it through to the underlying `ClientSession.call_tool()` call. Users needing dynamic, per-invocation metadata (e.g. correlation IDs, routing hints, tenant context) were blocked because only static connection-level headers were supported.

## Changes

**`langchain_mcp_adapters/interceptors.py`**
- Added `meta: NotRequired[dict[str, Any] | None]` to `_MCPToolCallRequestOverrides` TypedDict, enabling `request.override(meta={...})` in interceptors.
- Added `meta: dict[str, Any] | None = None` field to the `MCPToolCallRequest` dataclass so interceptors can read and modify it in the chain.

**`langchain_mcp_adapters/tools.py`**
- In `convert_mcp_tool_to_langchain_tool`, before constructing `MCPToolCallRequest`, pops `_meta` from `arguments` via `arguments.pop("_meta", None)` so it never reaches the downstream tool schema as an unexpected argument.
- Passes the extracted value as `meta=meta` when constructing `MCPToolCallRequest`.
- Forwards `meta=request.meta` to both `session.call_tool()` call sites (the streamable-HTTP path inside the context manager at line ~378 and the fallback path at line ~397), so the value set by the interceptor chain is what actually reaches the MCP SDK.

## Testing

Two new integration tests added to `tests/test_interceptors.py` under `TestInterceptorModifiesRequest`:

- **`test_meta_extracted_from_arguments`**: invokes an `add` tool with `{"a": 2, "b": 3, "_meta": {"session_id": "abc123"}}`, asserts the tool returns `5`, that an interceptor receives `request.meta == {"session_id": "abc123"}`, and that `_meta` is absent from `request.args`.
- **`test_interceptor_overrides_meta`**: an interceptor calls `request.override(meta={"user_id": "current-user"})` before forwarding; asserts the overridden value is what was captured and the tool still returns the correct result.

Both tests run against a live local streamable-HTTP math server (ports 8202 and 8210) to verify the full call path end-to-end.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*