### PR TITLE
Add Decision Anchor MCP integration example

### DIFF
--- a/examples/agents/decision-anchor/README.md
+++ b/examples/agents/decision-anchor/README.md
@@ -1,0 +1,33 @@
+# Decision Anchor MCP Integration Example
+
+A LangGraph ReAct agent that connects to [Decision Anchor](https://github.com/zse4321/decision-anchor-sdk)'s remote MCP server for external accountability proof.
+
+Decision Anchor provides external decision records for agent payments, delegation, and disputes via MCP. It does not monitor, judge, or intervene.
+
+## What this example does
+
+1. Connects to DA's remote MCP server (`https://mcp.decision-anchor.com/mcp`) via `MultiServerMCPClient`
+2. Registers as a new agent (one-time, no API key required)
+3. Creates a Decision Declaration (DD) with accountability scope
+4. Checks DAC balance
+
+## Usage
+
+```bash
+cd examples/agents/decision-anchor
+uv run decision-anchor-agent
+```
+
+Or run directly:
+
+```bash
+cd examples/agents/decision-anchor
+export OPENAI_API_KEY=your_key
+uv run python -m decision_anchor_agent
+```
+
+## Notes
+
+- No DA API key needed — agents register via MCP tools and receive Trial 500 DAC / 30 days
+- Running this example creates a real agent registration and decision record on DA
+- The MCP server uses streamable HTTP transport

--- a/examples/agents/decision-anchor/decision_anchor_agent/__init__.py
+++ b/examples/agents/decision-anchor/decision_anchor_agent/__init__.py
@@ -1,0 +1,1 @@
+"""Decision Anchor MCP integration agent."""

--- a/examples/agents/decision-anchor/decision_anchor_agent/__main__.py
+++ b/examples/agents/decision-anchor/decision_anchor_agent/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point for the Decision Anchor agent example."""
+
+from decision_anchor_agent.agent import main_sync
+
+main_sync()

--- a/examples/agents/decision-anchor/decision_anchor_agent/agent.py
+++ b/examples/agents/decision-anchor/decision_anchor_agent/agent.py
@@ -1,0 +1,74 @@
+"""LangGraph ReAct agent with Decision Anchor MCP integration.
+
+Connects to Decision Anchor's remote MCP server to create
+external accountability records for agent actions.
+
+Use case: an agent that makes API calls involving payments
+records each decision boundary externally via DA, so that
+payment disputes can reference externally-anchored proof
+rather than self-reported logs.
+"""
+
+import asyncio
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+model = ChatOpenAI(model="gpt-4o")
+
+
+async def main() -> None:
+    """Run the Decision Anchor integration example."""
+    async with MultiServerMCPClient(
+        {
+            "decision-anchor": {
+                "url": "https://mcp.decision-anchor.com/mcp",
+                "transport": "streamable_http",
+            }
+        }
+    ) as client:
+        tools = client.get_tools()
+        agent = create_react_agent(model, tools)
+
+        # Register as an agent (first time only, no API key needed)
+        result = await agent.ainvoke(
+            {
+                "messages": [
+                    "Register me as a new agent on Decision Anchor. "
+                    "Use agent name 'langgraph-demo-agent'."
+                ]
+            }
+        )
+        print("Registration:", result["messages"][-1].content)
+
+        # Create a DD (Decision Declaration) — records the
+        # accountability boundary for a payment action
+        result = await agent.ainvoke(
+            {
+                "messages": [
+                    "Create a Decision Declaration on Decision Anchor. "
+                    "Action type: execute. "
+                    "Summary: 'Authorized API payment of $12.50 to "
+                    "vendor-xyz for data enrichment service'. "
+                    "Use retention short, integrity basic, "
+                    "disclosure internal, responsibility minimal."
+                ]
+            }
+        )
+        print("DD Created:", result["messages"][-1].content)
+
+        # Check DAC balance
+        result = await agent.ainvoke(
+            {"messages": ["Check my DAC balance on Decision Anchor."]}
+        )
+        print("Balance:", result["messages"][-1].content)
+
+
+def main_sync() -> None:
+    """Synchronous wrapper for the async main function."""
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    main_sync()

--- a/examples/agents/decision-anchor/pyproject.toml
+++ b/examples/agents/decision-anchor/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "decision-anchor-agent"
+version = "0.1.0"
+description = "LangGraph ReAct agent with Decision Anchor MCP integration for external accountability proof"
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["mcp", "langchain", "langgraph", "accountability", "decision-anchor"]
+license = { text = "MIT" }
+dependencies = [
+    "langchain-mcp-adapters",
+    "langgraph",
+    "langchain-openai",
+]
+
+[project.scripts]
+decision-anchor-agent = "decision_anchor_agent.agent:main_sync"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["decision_anchor_agent"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+ignore = []
+
+[tool.ruff]
+line-length = 88
+target-version = "py310"
+
+[tool.uv]
+dev-dependencies = ["ruff>=0.6.9"]


### PR DESCRIPTION
## Summary

- Add a LangGraph ReAct agent example that connects to [Decision Anchor](https://github.com/zse4321/decision-anchor-sdk)'s remote MCP server via `MultiServerMCPClient`
- Decision Anchor is an external anchoring layer: it records the declared accountability scope for agent payments, delegation, and disputes via MCP. Content-blind — it records the declaration, never the decision's content.
- The example registers an agent, creates a Decision Declaration (DD) with accountability scope, and checks DAC balance
- No API key required for DA — agents register via MCP tools and receive Trial 500 DAC / 30 days

## Files

- `examples/agents/decision-anchor/` — standalone package following the existing `examples/servers/` structure
- `decision_anchor_agent/agent.py` — main agent logic using `MultiServerMCPClient` with streamable HTTP transport
- `pyproject.toml` — project config with `langchain-mcp-adapters`, `langgraph`, `langchain-openai` dependencies
- `README.md` — usage instructions

## Test plan

- [x] Python syntax validated (`ast.parse`)
- [x] `ruff check` and `ruff format --check` pass
- [ ] Manual run with `OPENAI_API_KEY` set: `cd examples/agents/decision-anchor && uv run decision-anchor-agent`
