### PR TITLE
feat(examples): add Global Chat MCP server — cross-protocol agent discovery

### DIFF
--- a/examples/servers/global-chat-discovery/README.md
+++ b/examples/servers/global-chat-discovery/README.md
@@ -1,0 +1,51 @@
+# Global Chat MCP Server Example
+
+A LangGraph agent example that connects to [Global Chat](https://global-chat.io)'s MCP server for cross-protocol agent and service discovery.
+
+## About Global Chat
+
+Global Chat is a cross-protocol agent discovery platform. Agents can search for other agents and services across MCP registries, A2A (Agent-to-Agent) protocol, and agents.txt endpoints.
+
+- **Repository:** [github.com/pumanitro/global-chat](https://github.com/pumanitro/global-chat)
+- **npm:** [@globalchatadsapp/mcp-server](https://www.npmjs.com/package/@globalchatadsapp/mcp-server)
+- **Transport:** stdio (via npx)
+
+## Tools Provided
+
+The MCP server exposes tools for:
+
+- Searching the agent/service directory
+- Discovering MCP servers, A2A agents, and agents.txt endpoints
+- Querying cross-protocol service metadata
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install langchain-mcp-adapters langgraph langchain-openai
+```
+
+Set your OpenAI API key:
+
+```bash
+export OPENAI_API_KEY=<your_api_key>
+```
+
+Ensure `npx` is available (requires Node.js):
+
+```bash
+node --version  # v18+ recommended
+```
+
+## Usage
+
+```bash
+python global_chat_example.py
+```
+
+The agent will connect to the Global Chat MCP server and can answer queries like:
+
+- "Find MCP servers related to payments"
+- "Search for AI agents that handle document processing"
+- "What agent discovery services are available?"

--- a/examples/servers/global-chat-discovery/global_chat_example.py
+++ b/examples/servers/global-chat-discovery/global_chat_example.py
@@ -1,0 +1,50 @@
+"""
+Global Chat MCP Server — Cross-protocol agent discovery for LangGraph agents.
+
+This example connects a LangGraph ReAct agent to the Global Chat MCP server,
+enabling it to search for agents and services across MCP registries,
+A2A protocol, and agents.txt endpoints.
+
+Requirements:
+    pip install langchain-mcp-adapters langgraph langchain-openai
+
+Usage:
+    export OPENAI_API_KEY=<your_api_key>
+    python global_chat_example.py
+"""
+
+import asyncio
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+
+from langchain_openai import ChatOpenAI
+
+model = ChatOpenAI(model="gpt-4o")
+
+
+async def main():
+    async with MultiServerMCPClient(
+        {
+            "global-chat": {
+                "command": "npx",
+                "args": ["-y", "@globalchatadsapp/mcp-server"],
+                "transport": "stdio",
+            }
+        }
+    ) as client:
+        tools = await client.get_tools()
+
+        agent = create_react_agent(model, tools)
+
+        # Example: search for payment-related MCP servers
+        response = await agent.ainvoke(
+            {"messages": [{"role": "user", "content": "Find MCP servers related to payments"}]}
+        )
+
+        for message in response["messages"]:
+            print(message.pretty_print())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Add a LangGraph ReAct agent example that connects to [Global Chat](https://global-chat.io)'s MCP server via `MultiServerMCPClient`
- Global Chat provides cross-protocol agent and service discovery across MCP registries, A2A protocol, and agents.txt endpoints
- The example shows stdio transport using `npx -y @globalchatadsapp/mcp-server`

## About Global Chat

- **Repository:** [github.com/pumanitro/global-chat](https://github.com/pumanitro/global-chat)
- **npm:** [@globalchatadsapp/mcp-server](https://www.npmjs.com/package/@globalchatadsapp/mcp-server)
- **What it does:** Agents can search for other agents and services across multiple discovery protocols (MCP, A2A, agents.txt)

## Files added

- `examples/servers/global-chat-discovery/README.md` — setup and usage docs
- `examples/servers/global-chat-discovery/global_chat_example.py` — working example with `MultiServerMCPClient` + `create_react_agent`

## Test plan

- [x] Python syntax validated
- [ ] Manual run with `OPENAI_API_KEY` set