### PR TITLE
Add mcp_server_name to tool metadata in convert_mcp_tool_to_langchain_tool

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -418,6 +418,10 @@ def convert_mcp_tool_to_langchain_tool(
     meta = {"_meta": meta} if meta is not None else {}
     metadata = {**base, **meta} or None
 
+    # Add the server name to the metadata
+    if server_name is not None:
+        metadata = {**(metadata or {}), "mcp_server_name": server_name}
+
     # Apply server name prefix if requested
     lc_tool_name = tool.name
     if tool_name_prefix and server_name:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1178,3 +1178,37 @@ async def test_get_tools_with_name_conflict(socket_enabled) -> None:
         assert len(tools) == 2
         tool_names = {t.name for t in tools}
         assert tool_names == {"weather_search", "flights_search"}
+
+
+async def test_get_tools_metadata_has_server_name(socket_enabled) -> None:
+    """Verify tool.metadata['mcp_server_name'] reflects the server key.
+
+    The metadata tag should match the key in self.connections regardless of
+    tool_name_prefix setting, providing authoritative client-side attribution.
+    """
+    with (
+        run_streamable_http(_create_weather_search_server, 8187),
+        run_streamable_http(_create_flights_search_server, 8188),
+    ):
+        for prefix in (True, False):
+            client = MultiServerMCPClient(
+                {
+                    "weather": {
+                        "url": "http://localhost:8187/mcp",
+                        "transport": "streamable_http",
+                    },
+                    "flights": {
+                        "url": "http://localhost:8188/mcp",
+                        "transport": "streamable_http",
+                    },
+                },
+                tool_name_prefix=prefix,
+            )
+            tools = await client.get_tools()
+            assert len(tools) == 2
+            for tool in tools:
+                assert tool.metadata is not None
+                assert "mcp_server_name" in tool.metadata
+                assert tool.metadata["mcp_server_name"] in {"weather", "flights"}
+            servers_seen = {t.metadata["mcp_server_name"] for t in tools}
+            assert servers_seen == {"weather", "flights"}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -590,6 +590,7 @@ async def test_load_mcp_tools_with_annotations(socket_enabled) -> None:
             "idempotentHint": False,
             "destructiveHint": None,
             "openWorldHint": None,
+            "mcp_server_name": "time"
         }
 
 


### PR DESCRIPTION
Closes #484.

When `MultiServerMCPClient.get_tools()` aggregates tools from multiple MCP servers, the server identity is currently only recoverable by parsing the prefix string from `tool.name` (and only when `tool_name_prefix=True`). If `tool_name_prefix=False`, the server identity is lost entirely after the aggregate list is returned.

This PR writes `tool.metadata["mcp_server_name"]` at the point where each tool is constructed in `convert_mcp_tool_to_langchain_tool`. The `server_name` is already threaded end-to-end through the call chain (`get_tools` → `load_mcp_tools` → `convert_mcp_tool_to_langchain_tool`), so this is an additive change with no signature impact.

This change is purely additive — it adds a new top-level key (`mcp_server_name`) to `tool.metadata`. Existing keys and consumers reading them are unaffected.

**Use case:** building a framework where MCP tools from multiple servers need attribution for telemetry and UI rendering. Parsing `tool.name.split("__")[0]` is fragile and doesn't work when `tool_name_prefix=False`.

**Collision behavior:** if an MCP server's `annotations` field contains a key named `mcp_server_name`, it will be overwritten by the client-configured server key (the key in `self.connections`). This is intentional — the metadata tag reflects client-side configuration, not a server self-declaration, so the value is consistent regardless of server behavior.

**Tests:**
- Added `test_get_tools_metadata_has_server_name` covering both `tool_name_prefix=True` and `tool_name_prefix=False`.
- Updated `test_load_mcp_tools_with_annotations` to include the new key in its expected dict.

`63 passed, 2 skipped` locally.