### PR TITLE
fix: expand ${VAR} references in HTTP/SSE transport headers

### DIFF
--- a/langchain_mcp_adapters/sessions.py
+++ b/langchain_mcp_adapters/sessions.py
@@ -46,6 +46,44 @@ def _expand_env_vars(value: str) -> str:
     return _BRACED_VAR_RE.sub(lambda m: os.environ.get(m.group(1), m.group(0)), value)
 
 
+def _expand_header_values(
+    headers: dict[str, Any] | None,
+    *,
+    transport: str,
+) -> dict[str, Any] | None:
+    """Expand `${VAR}` references in string-typed values of an HTTP header dict.
+
+    Mirrors the stdio `env` handling (see `_create_stdio_session`). Only
+    string values are touched; non-string values (rare but possible in some
+    client configs) pass through unchanged. `${VAR}` that refers to an unset
+    name is preserved as the literal string and a warning is logged, matching
+    stdio behavior.
+
+    Args:
+        headers: HTTP headers to process, or None to short-circuit.
+        transport: Transport name ("sse" / "streamable_http") used in the
+            warning message so operators know which connection is affected.
+
+    Returns:
+        A new dict with expanded values, or None if *headers* is None.
+    """
+    if headers is None:
+        return None
+    resolved: dict[str, Any] = {
+        k: (_expand_env_vars(v) if isinstance(v, str) else v)
+        for k, v in headers.items()
+    }
+    for k, v in resolved.items():
+        if isinstance(v, str) and _BRACED_VAR_RE.search(v):
+            logger.warning(
+                "%s header[%r] contains unexpanded variable reference: %r",
+                transport,
+                k,
+                v,
+            )
+    return resolved
+
+
 EncodingErrorHandler = Literal["strict", "ignore", "replace"]
 
 DEFAULT_ENCODING = "utf-8"
@@ -297,16 +335,17 @@ async def _create_sse_session(
     Yields:
         An initialized ClientSession.
     """
+    resolved_headers = _expand_header_values(headers, transport="sse")
+
     # Create and store the connection
     kwargs = {}
     if httpx_client_factory is not None:
         kwargs["httpx_client_factory"] = httpx_client_factory
 
     async with (
-        sse_client(url, headers, timeout, sse_read_timeout, auth=auth, **kwargs) as (
-            read,
-            write,
-        ),
+        sse_client(
+            url, resolved_headers, timeout, sse_read_timeout, auth=auth, **kwargs
+        ) as (read, write),
         ClientSession(read, write, **(session_kwargs or {})) as session,
     ):
         yield session
@@ -340,6 +379,8 @@ async def _create_streamable_http_session(
     Yields:
         An initialized ClientSession.
     """
+    resolved_headers = _expand_header_values(headers, transport="streamable_http")
+
     # Create and store the connection
     kwargs = {}
     if httpx_client_factory is not None:
@@ -348,7 +389,7 @@ async def _create_streamable_http_session(
     async with (
         streamablehttp_client(
             url,
-            headers,
+            resolved_headers,
             timeout,
             sse_read_timeout,
             terminate_on_close,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,11 @@ from langchain_core.messages import AIMessage
 from langchain_core.tools import BaseTool
 
 from langchain_mcp_adapters.client import MultiServerMCPClient
-from langchain_mcp_adapters.sessions import _create_stdio_session
+from langchain_mcp_adapters.sessions import (
+    _create_sse_session,
+    _create_stdio_session,
+    _create_streamable_http_session,
+)
 from langchain_mcp_adapters.tools import load_mcp_tools
 from tests.utils import IsLangChainID
 
@@ -115,6 +119,167 @@ async def test_stdio_session_warns_on_undefined_env_var(
         mock_stdio_session["server_params"].env["SECRET"]
         == "${TOTALLY_UNDEFINED_VAR_XYZ}"  # noqa: S105
     )
+
+
+@pytest.fixture
+def mock_sse_session() -> Generator[dict, None, None]:
+    """Patch sse_client and ClientSession.
+
+    Yields a dict with the positional args passed to sse_client so tests can
+    assert on the resolved headers (arg index 1).
+    """
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def fake_sse_client(*args: object, **kwargs: object):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        yield AsyncMock(), AsyncMock()
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=MagicMock())
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("langchain_mcp_adapters.sessions.sse_client", fake_sse_client),
+        patch(
+            "langchain_mcp_adapters.sessions.ClientSession",
+            return_value=mock_session,
+        ),
+    ):
+        yield captured
+
+
+@pytest.fixture
+def mock_http_session() -> Generator[dict, None, None]:
+    """Patch streamablehttp_client and ClientSession.
+
+    Yields a dict with the positional args passed to streamablehttp_client so
+    tests can assert on the resolved headers (arg index 1).
+    """
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def fake_streamablehttp_client(*args: object, **kwargs: object):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        yield AsyncMock(), AsyncMock(), AsyncMock()
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=MagicMock())
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "langchain_mcp_adapters.sessions.streamablehttp_client",
+            fake_streamablehttp_client,
+        ),
+        patch(
+            "langchain_mcp_adapters.sessions.ClientSession",
+            return_value=mock_session,
+        ),
+    ):
+        yield captured
+
+
+async def test_sse_session_expands_header_vars(monkeypatch, mock_sse_session):
+    """Test that ${VAR} references in SSE headers are expanded before connect."""
+    monkeypatch.setenv("TEST_MCP_TOKEN", "secret123")
+
+    async with _create_sse_session(
+        url="https://mcp.example.com/sse",
+        headers={
+            "Authorization": "Bearer ${TEST_MCP_TOKEN}",
+            "X-Literal": "plain",
+            "X-Embedded": "t=${TEST_MCP_TOKEN};v=1",
+        },
+    ):
+        pass
+
+    # sse_client is called as sse_client(url, headers, timeout, sse_read_timeout, ...)
+    resolved_headers = mock_sse_session["args"][1]
+    assert resolved_headers["Authorization"] == "Bearer secret123"
+    assert resolved_headers["X-Literal"] == "plain"
+    assert resolved_headers["X-Embedded"] == "t=secret123;v=1"
+
+
+async def test_sse_session_headers_none_stays_none(mock_sse_session):
+    """Test that headers=None is passed through as None."""
+    async with _create_sse_session(url="https://mcp.example.com/sse"):
+        pass
+
+    assert mock_sse_session["args"][1] is None
+
+
+async def test_sse_session_bare_dollar_not_expanded(monkeypatch, mock_sse_session):
+    """Bare $VAR header values must NOT be expanded — only ${VAR} is supported."""
+    monkeypatch.setenv("word123", "OOPS")
+
+    async with _create_sse_session(
+        url="https://mcp.example.com/sse",
+        headers={"X-Trace": "req=$word123"},
+    ):
+        pass
+
+    assert mock_sse_session["args"][1]["X-Trace"] == "req=$word123"
+
+
+async def test_sse_session_warns_on_undefined_header_var(
+    monkeypatch, mock_sse_session, caplog
+):
+    """Test that undefined ${VAR} references in headers emit a warning."""
+    monkeypatch.delenv("TOTALLY_UNDEFINED_VAR_XYZ", raising=False)
+
+    with caplog.at_level(logging.WARNING, logger="langchain_mcp_adapters.sessions"):
+        async with _create_sse_session(
+            url="https://mcp.example.com/sse",
+            headers={"Authorization": "Bearer ${TOTALLY_UNDEFINED_VAR_XYZ}"},
+        ):
+            pass
+
+    assert "unexpanded variable reference" in caplog.text
+    # Preserved literal when undefined, same as stdio behavior
+    assert (
+        mock_sse_session["args"][1]["Authorization"]
+        == "Bearer ${TOTALLY_UNDEFINED_VAR_XYZ}"
+    )
+
+
+async def test_streamable_http_session_expands_header_vars(
+    monkeypatch, mock_http_session
+):
+    """Test that ${VAR} in streamable_http headers are expanded before connect."""
+    monkeypatch.setenv("TEST_MCP_TOKEN", "secret123")
+
+    async with _create_streamable_http_session(
+        url="https://mcp.example.com/http",
+        headers={
+            "Authorization": "Bearer ${TEST_MCP_TOKEN}",
+            "X-Literal": "plain",
+        },
+    ):
+        pass
+
+    # streamablehttp_client is called as streamablehttp_client(url, headers, ...)
+    resolved_headers = mock_http_session["args"][1]
+    assert resolved_headers["Authorization"] == "Bearer secret123"
+    assert resolved_headers["X-Literal"] == "plain"
+
+
+async def test_streamable_http_session_warns_on_undefined_header_var(
+    monkeypatch, mock_http_session, caplog
+):
+    """Test that undefined ${VAR} in streamable_http headers emits a warning."""
+    monkeypatch.delenv("TOTALLY_UNDEFINED_VAR_XYZ", raising=False)
+
+    with caplog.at_level(logging.WARNING, logger="langchain_mcp_adapters.sessions"):
+        async with _create_streamable_http_session(
+            url="https://mcp.example.com/http",
+            headers={"Authorization": "Bearer ${TOTALLY_UNDEFINED_VAR_XYZ}"},
+        ):
+            pass
+
+    assert "unexpanded variable reference" in caplog.text
 
 
 async def test_multi_server_mcp_client(


### PR DESCRIPTION
## What this changes

PR #438 introduced `_expand_env_vars` and wired it into
`_create_stdio_session` so stdio server configs could reference
`${VAR}` in their `env` dict and have it resolved at connect time.
The same substitution was never added to the HTTP/SSE transports —
`_create_sse_session` and `_create_streamable_http_session` forward
their `headers=` dict to `sse_client` / `streamablehttp_client`
verbatim. That means a connection config like:

```python
{
    "transport": "streamable_http",
    "url": "https://api.githubcopilot.com/mcp/",
    "headers": {"Authorization": "Bearer ${GITHUB_TOKEN}"},
}
```

sends the literal string `Bearer ${GITHUB_TOKEN}` on the wire and the
MCP server returns 401.

## What this PR does

1. Adds a `_expand_header_values` helper alongside `_expand_env_vars`
   that walks a `headers` dict and substitutes `${VAR}` inside string
   values only. Non-string entries (uncommon but legal in some httpx
   configs) pass through unchanged. Undefined references preserve the
   literal `${NAME}` and emit a warning — exact parity with stdio.
2. `_create_sse_session` and `_create_streamable_http_session` now call
   the helper once at the top of the function and pass the resolved
   dict to their underlying transport clients.
3. The warning includes the transport name (`sse` vs
   `streamable_http`) so operators running multiple connections can
   tell which one is misconfigured.
4. `_create_websocket_session` has no `headers` parameter and is left
   untouched.

## Tests

Mirrors the four existing stdio-env tests in `tests/test_client.py`:

- `test_sse_session_expands_header_vars` — baseline expansion, literal
  pass-through, embedded substitutions.
- `test_sse_session_headers_none_stays_none` — `None` in, `None` out.
- `test_sse_session_bare_dollar_not_expanded` — only `${VAR}` is
  expanded; bare `$VAR` stays literal (matches stdio).
- `test_sse_session_warns_on_undefined_header_var` — warning is
  emitted and the value is preserved as literal.
- `test_streamable_http_session_expands_header_vars` — same baseline
  on the http transport.
- `test_streamable_http_session_warns_on_undefined_header_var` — same
  warning behavior on the http transport.

Two new fixtures (`mock_sse_session`, `mock_http_session`) mirror the
existing `mock_stdio_session` fixture. All 77 tests in
`tests/test_client.py` pass locally.

## Motivation

Downstream usage in the `deepagents` LangGraph agent framework hit
this immediately: an MCP GitHub connection configured via
`mcp.json` with `"Authorization": "Bearer \${GITHUB_TOKEN}"`
silently 401'd despite the token being correctly set in the process
env. The current workaround is a `sitecustomize.py` monkey-patch that
wraps the two factories to run `headers` through `_expand_env_vars`
before forwarding. Landing this upstream removes the need for that
patch and brings http/sse transports in line with stdio's documented
behavior.

## Scope

Deliberately minimal — same helper, same warning shape, same
precedence (braced-only) as the stdio fix in #438. Doesn't introduce
new config surfaces, doesn't change any public API, doesn't alter
stdio behavior.