### PR TITLE
fix(client): isolate server failures in MultiServerMCPClient.get_tools

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -5,6 +5,7 @@ to multiple MCP servers and loading tools, prompts, and resources from them.
 """
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import TracebackType
@@ -29,6 +30,8 @@ from langchain_mcp_adapters.sessions import (
     create_session,
 )
 from langchain_mcp_adapters.tools import load_mcp_tools
+
+logger = logging.getLogger(__name__)
 
 ASYNC_CONTEXT_MANAGER_ERROR = (
     "As of langchain-mcp-adapters 0.1.0, MultiServerMCPClient cannot be used as a "
@@ -181,12 +184,13 @@ class MultiServerMCPClient:
             )
 
         all_tools: list[BaseTool] = []
+        server_names = list(self.connections.keys())
         load_mcp_tool_tasks = []
-        for name, connection in self.connections.items():
+        for name in server_names:
             load_mcp_tool_task = asyncio.create_task(
                 load_mcp_tools(
                     None,
-                    connection=connection,
+                    connection=self.connections[name],
                     callbacks=self.callbacks,
                     server_name=name,
                     tool_interceptors=self.tool_interceptors,
@@ -194,9 +198,16 @@ class MultiServerMCPClient:
                 )
             )
             load_mcp_tool_tasks.append(load_mcp_tool_task)
-        tools_list = await asyncio.gather(*load_mcp_tool_tasks)
-        for tools in tools_list:
-            all_tools.extend(tools)
+        # Use return_exceptions=True so a single failing server does not cancel
+        # the others and drop tools from healthy servers (#492).
+        results = await asyncio.gather(*load_mcp_tool_tasks, return_exceptions=True)
+        for name, result in zip(server_names, results):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Failed to load tools from MCP server '%s': %s", name, result
+                )
+                continue
+            all_tools.extend(result)
         return all_tools
 
     async def get_prompt(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -351,3 +351,39 @@ async def test_get_resources_from_specific_server():
     assert len(weather_resources) == 1
     assert str(weather_resources[0].metadata["uri"]) == "weather://forecast"
     assert weather_resources[0].data == "Sunny with a chance of clouds"
+
+
+async def test_get_tools_isolates_failing_server(caplog):
+    """A single failing server must not drop tools from healthy servers (#492)."""
+    healthy_tool = MagicMock(spec=BaseTool)
+    healthy_tool.name = "healthy_tool"
+
+    async def fake_load_mcp_tools(_session, *, server_name, **_kwargs):
+        if server_name == "broken":
+            raise FileNotFoundError("npx: command not found")
+        return [healthy_tool]
+
+    client = MultiServerMCPClient(
+        {
+            "broken": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+                "transport": "stdio",
+            },
+            "healthy": {
+                "url": "http://localhost:8092/mcp/mcp",
+                "transport": "streamable_http",
+            },
+        }
+    )
+
+    with (
+        patch("langchain_mcp_adapters.client.load_mcp_tools", new=fake_load_mcp_tools),
+        caplog.at_level(logging.WARNING, logger="langchain_mcp_adapters.client"),
+    ):
+        tools = await client.get_tools()
+
+    # Healthy server's tools survive; broken server's failure is logged.
+    assert tools == [healthy_tool]
+    assert "broken" in caplog.text
+    assert "npx" in caplog.text


### PR DESCRIPTION
Closes #492.

`MultiServerMCPClient.get_tools` called `asyncio.gather` without `return_exceptions=True`, so a single failing server caused the whole call to return early and drop tools from healthy servers. Switched to `return_exceptions=True` and skip-with-warning on per-server failures.

Test added in `tests/test_client.py::test_get_tools_isolates_failing_server`.
