### PR TITLE
feat(websocket): support custom headers in MultiServerMCPClient (closes #489)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ When connecting to MCP servers, you can include custom headers (e.g., for authen
 
 - `sse`
 - `http` (or `streamable_http`)
+- `websocket` (sent during the WebSocket handshake)
 
 ### Example: passing headers with `MultiServerMCPClient`
 
@@ -233,7 +234,7 @@ agent = create_agent("openai:gpt-4.1", tools)
 response = await agent.ainvoke({"messages": "what is the weather in nyc?"})
 ```
 
-> Only `sse` and `http` transports support runtime headers. These headers are passed with every HTTP request to the MCP server.
+> `sse` and `http` headers are sent with every HTTP request to the MCP server. `websocket` headers are sent only on the initial WebSocket handshake (typical for `Authorization: Bearer ...` tokens).
 
 ## Using with LangGraph StateGraph
 

--- a/langchain_mcp_adapters/sessions.py
+++ b/langchain_mcp_adapters/sessions.py
@@ -201,6 +201,16 @@ class WebsocketConnection(TypedDict):
     url: str
     """The URL of the Websocket endpoint to connect to."""
 
+    headers: NotRequired[dict[str, Any] | None]
+    """HTTP headers to send during the WebSocket handshake.
+
+    Useful for passing authentication tokens (e.g. ``Authorization: Bearer ...``)
+    or other custom headers required by the upstream MCP server.
+
+    When omitted, the upstream MCP SDK ``websocket_client`` is used unchanged
+    to preserve full backward-compatibility.
+    """
+
     session_kwargs: NotRequired[dict[str, Any] | None]
     """Additional keyword arguments to pass to the ClientSession"""
 
@@ -361,15 +371,89 @@ async def _create_streamable_http_session(
 
 
 @asynccontextmanager
+async def _websocket_client_with_headers(
+    url: str,
+    headers: dict[str, Any] | None,
+) -> AsyncIterator[tuple[Any, Any]]:
+    """WebSocket client that mirrors ``mcp.client.websocket.websocket_client``.
+
+    The upstream MCP SDK's ``websocket_client`` only accepts a ``url`` argument
+    and does not forward HTTP handshake headers (see
+    https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/websocket.py).
+
+    We replicate its read/write loop here so callers can supply custom headers
+    (e.g. ``Authorization: Bearer ...``) on the WebSocket handshake. This path
+    is only taken when ``headers`` is provided; otherwise the upstream client
+    is used unchanged.
+    """
+    # Local imports keep websockets/anyio out of the import path when WebSockets
+    # are not in use (matches upstream MCP SDK behavior).
+    import json  # noqa: PLC0415
+
+    import anyio  # noqa: PLC0415
+    from mcp import types  # noqa: PLC0415
+    from mcp.shared.message import SessionMessage  # noqa: PLC0415
+    from pydantic import ValidationError  # noqa: PLC0415
+    from websockets.asyncio.client import connect as ws_connect  # noqa: PLC0415
+    from websockets.typing import Subprotocol  # noqa: PLC0415
+
+    read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+
+    async with ws_connect(
+        url,
+        subprotocols=[Subprotocol("mcp")],
+        additional_headers=headers,
+    ) as ws:
+
+        async def ws_reader() -> None:
+            async with read_stream_writer:
+                async for raw_text in ws:
+                    try:
+                        # `jsonrpc_message_adapter` exists on newer MCP SDKs;
+                        # fall back to `JSONRPCMessage.model_validate_json`
+                        # for older releases.
+                        adapter = getattr(types, "jsonrpc_message_adapter", None)
+                        if adapter is not None:
+                            message = adapter.validate_json(raw_text, by_name=False)
+                        else:
+                            message = types.JSONRPCMessage.model_validate_json(
+                                raw_text
+                            )
+                        await read_stream_writer.send(SessionMessage(message))
+                    except ValidationError as exc:
+                        await read_stream_writer.send(exc)
+
+        async def ws_writer() -> None:
+            async with write_stream_reader:
+                async for session_message in write_stream_reader:
+                    msg_dict = session_message.message.model_dump(
+                        by_alias=True, mode="json", exclude_none=True
+                    )
+                    await ws.send(json.dumps(msg_dict))
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(ws_reader)
+            tg.start_soon(ws_writer)
+            yield (read_stream, write_stream)
+            tg.cancel_scope.cancel()
+
+
+@asynccontextmanager
 async def _create_websocket_session(
     *,
     url: str,
+    headers: dict[str, Any] | None = None,
     session_kwargs: dict[str, Any] | None = None,
 ) -> AsyncIterator[ClientSession]:
     """Create a new session to an MCP server using Websockets.
 
     Args:
         url: URL of the Websocket endpoint.
+        headers: HTTP headers to send during the WebSocket handshake (e.g.
+            ``{"Authorization": "Bearer ..."}``). When omitted, the upstream
+            MCP SDK ``websocket_client`` is used unchanged for full
+            backward-compatibility.
         session_kwargs: Additional keyword arguments to pass to the ClientSession.
 
     Yields:
@@ -388,8 +472,15 @@ async def _create_websocket_session(
         )
         raise ImportError(msg) from None
 
+    if headers:
+        # Use the local header-aware client; upstream `websocket_client` does
+        # not yet accept headers (see _websocket_client_with_headers).
+        client_cm = _websocket_client_with_headers(url, headers)
+    else:
+        client_cm = websocket_client(url)
+
     async with (
-        websocket_client(url) as (read, write),
+        client_cm as (read, write),
         ClientSession(read, write, **(session_kwargs or {})) as session,
     ):
         yield session

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,10 @@ from langchain_core.messages import AIMessage
 from langchain_core.tools import BaseTool
 
 from langchain_mcp_adapters.client import MultiServerMCPClient
-from langchain_mcp_adapters.sessions import _create_stdio_session
+from langchain_mcp_adapters.sessions import (
+    _create_stdio_session,
+    _create_websocket_session,
+)
 from langchain_mcp_adapters.tools import load_mcp_tools
 from tests.utils import IsLangChainID
 
@@ -115,6 +118,93 @@ async def test_stdio_session_warns_on_undefined_env_var(
         mock_stdio_session["server_params"].env["SECRET"]
         == "${TOTALLY_UNDEFINED_VAR_XYZ}"  # noqa: S105
     )
+
+
+async def test_websocket_session_forwards_custom_headers():
+    """Custom headers must reach the WebSocket handshake.
+
+    Regression test for https://github.com/langchain-ai/langchain-mcp-adapters/issues/489.
+    The upstream MCP SDK's `websocket_client(url)` does not accept a `headers`
+    kwarg, so when headers are provided we route through our local
+    `_websocket_client_with_headers` instead. This test pins that behavior:
+    when `headers=` is passed to `_create_websocket_session`, our local
+    header-aware client receives them.
+    """
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def fake_client(url, headers):
+        captured["url"] = url
+        captured["headers"] = headers
+        yield AsyncMock(), AsyncMock()
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=MagicMock())
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "langchain_mcp_adapters.sessions._websocket_client_with_headers",
+            fake_client,
+        ),
+        patch(
+            "langchain_mcp_adapters.sessions.ClientSession",
+            return_value=mock_session,
+        ),
+    ):
+        async with _create_websocket_session(
+            url="ws://example.test/ws",
+            headers={"Authorization": "Bearer token-123"},
+        ):
+            pass
+
+    assert captured["url"] == "ws://example.test/ws"
+    assert captured["headers"] == {"Authorization": "Bearer token-123"}
+
+
+async def test_websocket_session_without_headers_uses_upstream_client():
+    """When no headers are provided, the upstream `websocket_client` is used.
+
+    Keeps the path that calls into the MCP SDK unchanged for full
+    backward-compatibility.
+    """
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def fake_upstream(url):
+        captured["url"] = url
+        captured["called"] = True
+        yield AsyncMock(), AsyncMock()
+
+    @asynccontextmanager
+    async def fake_with_headers(url, headers):  # pragma: no cover - must not run
+        captured["with_headers_called"] = True
+        yield AsyncMock(), AsyncMock()
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=MagicMock())
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    # Patch the import target inside `_create_websocket_session`. The function
+    # does `from mcp.client.websocket import websocket_client` at call time, so
+    # we must patch it at the source.
+    with (
+        patch("mcp.client.websocket.websocket_client", fake_upstream),
+        patch(
+            "langchain_mcp_adapters.sessions._websocket_client_with_headers",
+            fake_with_headers,
+        ),
+        patch(
+            "langchain_mcp_adapters.sessions.ClientSession",
+            return_value=mock_session,
+        ),
+    ):
+        async with _create_websocket_session(url="ws://example.test/ws"):
+            pass
+
+    assert captured.get("called") is True
+    assert captured["url"] == "ws://example.test/ws"
+    assert "with_headers_called" not in captured
 
 
 async def test_multi_server_mcp_client(


### PR DESCRIPTION
## Why

Closes #489.

`MultiServerMCPClient` already accepts a `headers` field for the `sse` and `streamable_http` transports (commonly used to pass `Authorization: Bearer ...` tokens). The `websocket` transport silently doesn't, and today the same config raises:

```
TypeError: _create_websocket_session() got an unexpected keyword argument 'headers'
```

This brings the `websocket` transport to parity with `streamable_http` so the same auth pattern works regardless of transport choice.

## What

- Add a `headers: dict[str, str] | None` field to `WebsocketConnection` (mirrors the shape used by `SSEConnection` / `StreamableHttpConnection`).
- Plumb `headers` through `_create_websocket_session(...)`.
- The upstream MCP SDK's `mcp.client.websocket.websocket_client(url)` does not accept a `headers` kwarg today (see [upstream source](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/websocket.py)), so when `headers` are provided we route through a small local `_websocket_client_with_headers` that mirrors the upstream read/write loop and forwards `additional_headers=` to `websockets.asyncio.client.connect`. When no headers are passed, we still call upstream `websocket_client(url)` unchanged for full backward-compat.
- README updated to list `websocket` alongside `sse` / `http` for runtime headers.

Example (the snippet from #489 now works):

```python
client = MultiServerMCPClient({
    "mcp-server": {
        "transport": "websocket",
        "url": url,
        "headers": {"Authorization": f"Bearer {token}"},
    }
})
tools = await client.get_tools()
```

## Tested

- New unit test `test_websocket_session_forwards_custom_headers` patches `_websocket_client_with_headers` and asserts the URL + headers reach the WebSocket handshake.
- New unit test `test_websocket_session_without_headers_uses_upstream_client` pins the back-compat path: when no `headers` are passed, the upstream `mcp.client.websocket.websocket_client` is called and the local header-aware client is not.
- The existing `test_multi_server_mcp_client` integration test (which spins up a real WebSocket MCP server and connects with no headers) is unchanged and still exercises the upstream path.
