### PR TITLE
fix(client): isolate per-server failures in MultiServerMCPClient.get_tools (#492)

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -5,6 +5,7 @@ to multiple MCP servers and loading tools, prompts, and resources from them.
 """
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import TracebackType
@@ -29,6 +30,8 @@ from langchain_mcp_adapters.sessions import (
     create_session,
 )
 from langchain_mcp_adapters.tools import load_mcp_tools
+
+logger = logging.getLogger(__name__)
 
 ASYNC_CONTEXT_MANAGER_ERROR = (
     "As of langchain-mcp-adapters 0.1.0, MultiServerMCPClient cannot be used as a "
@@ -160,6 +163,13 @@ class MultiServerMCPClient:
 
             A new session will be created for each tool call
 
+        !!! note
+
+            When loading from all servers, a failure on any single server is
+            isolated: a warning is logged for that server and tools from the
+            remaining healthy servers are still returned. When `server_name`
+            is provided, errors propagate to the caller as before.
+
         Returns:
             A list of LangChain [tools](https://docs.langchain.com/oss/python/langchain/tools)
 
@@ -181,8 +191,10 @@ class MultiServerMCPClient:
             )
 
         all_tools: list[BaseTool] = []
+        server_names = list(self.connections.keys())
         load_mcp_tool_tasks = []
-        for name, connection in self.connections.items():
+        for name in server_names:
+            connection = self.connections[name]
             load_mcp_tool_task = asyncio.create_task(
                 load_mcp_tools(
                     None,
@@ -194,9 +206,17 @@ class MultiServerMCPClient:
                 )
             )
             load_mcp_tool_tasks.append(load_mcp_tool_task)
-        tools_list = await asyncio.gather(*load_mcp_tool_tasks)
-        for tools in tools_list:
-            all_tools.extend(tools)
+        # Use return_exceptions=True so a single failing server (e.g. a stdio
+        # command that is not installed) does not cancel sibling tasks and lose
+        # tools from healthy servers. See issue #492.
+        results = await asyncio.gather(*load_mcp_tool_tasks, return_exceptions=True)
+        for name, result in zip(server_names, results):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Failed to load tools from MCP server %r: %s", name, result
+                )
+                continue
+            all_tools.extend(result)
         return all_tools
 
     async def get_prompt(
@@ -288,3 +308,4 @@ __all__ = [
     "StreamableHttpConnection",
     "WebsocketConnection",
 ]
+</content>

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -351,3 +351,103 @@ async def test_get_resources_from_specific_server():
     assert len(weather_resources) == 1
     assert str(weather_resources[0].metadata["uri"]) == "weather://forecast"
     assert weather_resources[0].data == "Sunny with a chance of clouds"
+
+
+async def test_get_tools_isolates_per_server_failures(caplog):
+    """A failing server must not prevent healthy servers from returning tools.
+
+    Regression test for https://github.com/langchain-ai/langchain-mcp-adapters/issues/492:
+    `MultiServerMCPClient.get_tools()` previously used `asyncio.gather` without
+    `return_exceptions=True`, so a single failing server (e.g. a stdio command
+    that is not on PATH) caused the whole call to raise and all tools — even
+    from healthy servers — were lost.
+    """
+    healthy_tool = MagicMock(spec=BaseTool)
+    healthy_tool.name = "healthy_tool"
+
+    async def fake_load_mcp_tools(
+        session,
+        *,
+        connection,
+        callbacks,
+        server_name,
+        tool_interceptors,
+        tool_name_prefix,
+    ):
+        if server_name == "broken":
+            raise FileNotFoundError("npx: command not found")
+        return [healthy_tool]
+
+    client = MultiServerMCPClient(
+        {
+            "broken": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+                "transport": "stdio",
+            },
+            "healthy": {
+                "url": "http://localhost:8092/mcp/mcp",
+                "transport": "streamable_http",
+            },
+        }
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="langchain_mcp_adapters.client"),
+        patch(
+            "langchain_mcp_adapters.client.load_mcp_tools",
+            side_effect=fake_load_mcp_tools,
+        ),
+    ):
+        tools = await client.get_tools()
+
+    # Healthy server's tools must still be returned.
+    assert tools == [healthy_tool]
+
+    # Broken server's failure must be logged with the server name surfaced.
+    assert "broken" in caplog.text
+    assert "npx: command not found" in caplog.text
+
+
+async def test_get_tools_all_servers_failing_returns_empty(caplog):
+    """If every server fails, get_tools() returns [] and warns for each."""
+
+    async def always_fail(
+        session,
+        *,
+        connection,
+        callbacks,
+        server_name,
+        tool_interceptors,
+        tool_name_prefix,
+    ):
+        raise RuntimeError(f"boom from {server_name}")
+
+    client = MultiServerMCPClient(
+        {
+            "a": {
+                "command": "python3",
+                "args": ["/nope/a.py"],
+                "transport": "stdio",
+            },
+            "b": {
+                "command": "python3",
+                "args": ["/nope/b.py"],
+                "transport": "stdio",
+            },
+        }
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="langchain_mcp_adapters.client"),
+        patch(
+            "langchain_mcp_adapters.client.load_mcp_tools",
+            side_effect=always_fail,
+        ),
+    ):
+        tools = await client.get_tools()
+
+    assert tools == []
+    assert "boom from a" in caplog.text
+    assert "boom from b" in caplog.text
+</content>


### PR DESCRIPTION
## Summary

Fixes #492.

`MultiServerMCPClient.get_tools()` (no `server_name`) previously called `asyncio.gather(*tasks)` without `return_exceptions=True`. As a result, the first failing server (e.g. a `stdio` command that is not on `PATH`, like `npx` inside a Docker image without Node.js) propagated its exception out of the gather and the caller lost tools from every healthy server too — `get_tools()` either raised or returned `[]`.

This PR isolates per-server failures:

- `asyncio.gather(..., return_exceptions=True)` collects each task's outcome instead of cancelling siblings on the first failure.
- Each result is paired with its originating server name. Exceptions are logged on `langchain_mcp_adapters.client` at `WARNING` (matching the existing `logger.warning(...)` style used in `langchain_mcp_adapters/sessions.py`) and the server is skipped. Successful results extend the tool list as before.
- The single-server `get_tools(server_name=...)` path is unchanged; errors there still propagate to the caller, which is the existing behaviour and matches what callers asking for one specific server would expect.

## Tests

Added two regression tests in `tests/test_client.py` that mock `langchain_mcp_adapters.client.load_mcp_tools`:

- `test_get_tools_isolates_per_server_failures` — one broken server (`FileNotFoundError`, mirroring the issue's `npx not installed` case) plus one healthy server. Asserts the healthy server's tool is returned and the broken server's failure is logged with the server name and the underlying error message.
- `test_get_tools_all_servers_failing_returns_empty` — every server fails. Asserts `get_tools()` returns `[]` and every server gets a warning entry.

## Test plan

- [ ] `make test` (or `uv run pytest --disable-socket --allow-unix-socket tests/ --timeout 10`) passes locally
- [ ] `tests/test_client.py::test_get_tools_isolates_per_server_failures` passes
- [ ] `tests/test_client.py::test_get_tools_all_servers_failing_returns_empty` passes
- [ ] Existing `test_multi_server_mcp_client` still passes (no behaviour change for the all-healthy path)
