### PR TITLE
fix(core): correct exception type and __aexit__ implementation  Fixes #496

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -260,7 +260,7 @@ class MultiServerMCPClient:
         """
         raise NotImplementedError(ASYNC_CONTEXT_MANAGER_ERROR)
 
-    def __aexit__(
+    async def __aexit__(
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,

--- a/langchain_mcp_adapters/resources.py
+++ b/langchain_mcp_adapters/resources.py
@@ -30,7 +30,7 @@ def convert_mcp_resource_to_langchain_blob(
         data = base64.b64decode(contents.blob)
     else:
         msg = f"Unsupported content type for URI {resource_uri}"
-        raise TypeError(msg)
+        raise ValueError(msg)
 
     return Blob.from_data(
         data=data, mime_type=contents.mimeType, metadata={"uri": resource_uri}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -351,3 +351,14 @@ async def test_get_resources_from_specific_server():
     assert len(weather_resources) == 1
     assert str(weather_resources[0].metadata["uri"]) == "weather://forecast"
     assert weather_resources[0].data == "Sunny with a chance of clouds"
+
+
+async def test_client_async_context_manager_raises_not_implemented_error():
+    """Test that using MultiServerMCPClient as an async context manager raises NotImplementedError."""
+    client = MultiServerMCPClient({})
+    
+    from langchain_mcp_adapters.client import ASYNC_CONTEXT_MANAGER_ERROR
+    
+    with pytest.raises(NotImplementedError, match=ASYNC_CONTEXT_MANAGER_ERROR[:50]):
+        async with client:
+            pass

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -53,7 +53,10 @@ def test_convert_mcp_resource_to_langchain_blob_with_invalid_type():
         pass
 
     with pytest.raises(ValueError):
-        convert_mcp_resource_to_langchain_blob("file:///dummy", DummyContent())
+        # We need to construct DummyContent manually to bypass pydantic validation
+        # so we can actually reach the else branch in convert_mcp_resource_to_langchain_blob
+        dummy = object.__new__(DummyContent)
+        convert_mcp_resource_to_langchain_blob("file:///dummy", dummy)
 
 
 async def test_get_mcp_resource_with_contents():


### PR DESCRIPTION
Fixes #496
- resources.py: Change TypeError to ValueError for unsupported content types
- client.py: Make __aexit__ an async coroutine
- tests: Add regression tests for both fixes