### PR TITLE
feat: MCP prompts list/get, bind_mcp_prompt, and LangGraph injection node

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This library provides a lightweight wrapper that makes [Anthropic Model Context 
 - 📦 A client implementation that allows you to connect to multiple MCP servers and load tools from them
 - 📝 MCP **prompts/list** and **prompts/get**: `MultiServerMCPClient.list_prompts()` discovers prompt templates (metadata); `get_prompt()` loads rendered messages for a chosen template (same split as the [MCP Inspector](https://www.npmjs.com/package/@modelcontextprotocol/inspector) flow)
 - 🔗 **`bind_mcp_prompt`**: compose MCP prompt messages with a chat model in one runnable (same idea as `model.bind_tools(tools)` — prepend template content, then invoke the model); see [`langchain_mcp_adapters.prompt_binder`](langchain_mcp_adapters/prompt_binder.py)
+- **`create_mcp_prompt_injection_node`**: LangGraph-only node that writes MCP prompt messages into state (`prepend` / `append`); see [`langchain_mcp_adapters.langgraph_prompt`](langchain_mcp_adapters/langgraph_prompt.py)
 
 ## Installation
 
@@ -306,6 +307,35 @@ reply = await bound.ainvoke("What is 7 * 8?")
 ```
 
 For LangGraph state with extra fields, pass **`arguments_resolver=lambda state: {...}`** so template arguments can depend on `state`.
+
+## MCP prompt injection node (LangGraph)
+
+To update only the graph state (like **`ToolNode`** updates messages with tool results), use **`create_mcp_prompt_injection_node`**: it calls **`prompts/get`** and returns a **`messages`** update for **`add_messages`** / **`MessagesState`**.
+
+- **`placement="prepend"`** (default): MCP messages appear **before** the current history (LangGraph **`RemoveMessage(REMOVE_ALL_MESSAGES)`** + full list pattern).
+- **`placement="append"`**: MCP messages are **appended** after existing messages.
+
+```python
+from langgraph.graph import END, MessagesState, START, StateGraph
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.langgraph_prompt import create_mcp_prompt_injection_node
+
+client = MultiServerMCPClient({...})
+inject = create_mcp_prompt_injection_node(
+    client,
+    "math",
+    "configure_assistant",
+    arguments={"skills": "algebra"},
+)
+
+builder = StateGraph(MessagesState)
+builder.add_node("mcp_prompt", inject)
+builder.add_edge(START, "mcp_prompt")
+# builder.add_edge("mcp_prompt", "agent")  # then your model node
+```
+
+Requires **`langgraph`** (declared in the library’s **test** dependency group for contributors; install in your app with `pip install langgraph`).
 
 ## Using with LangGraph API Server
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This library provides a lightweight wrapper that makes [Anthropic Model Context 
 - 🛠️ Convert MCP tools into [LangChain tools](https://python.langchain.com/docs/concepts/tools/) that can be used with [LangGraph](https://github.com/langchain-ai/langgraph) agents
 - 📦 A client implementation that allows you to connect to multiple MCP servers and load tools from them
 - 📝 MCP **prompts/list** and **prompts/get**: `MultiServerMCPClient.list_prompts()` discovers prompt templates (metadata); `get_prompt()` loads rendered messages for a chosen template (same split as the [MCP Inspector](https://www.npmjs.com/package/@modelcontextprotocol/inspector) flow)
+- 🔗 **`bind_mcp_prompt`**: compose MCP prompt messages with a chat model in one runnable (same idea as `model.bind_tools(tools)` — prepend template content, then invoke the model); see [`langchain_mcp_adapters.prompt_binder`](langchain_mcp_adapters/prompt_binder.py)
 
 ## Installation
 
@@ -280,6 +281,31 @@ graph = builder.compile()
 math_response = await graph.ainvoke({"messages": "what's (3 + 5) x 12?"})
 weather_response = await graph.ainvoke({"messages": "what is the weather in nyc?"})
 ```
+
+## MCP prompts and `bind_mcp_prompt`
+
+MCP does not define a `bind_prompt` on the LLM; prompts are messages from **`prompts/get`**. Use **`bind_mcp_prompt`** to prepend those messages, then call the model (same chaining idea as **`bind_tools`** + **`ToolNode`** for tools):
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.prompt_binder import bind_mcp_prompt
+from langchain.chat_models import init_chat_model
+
+client = MultiServerMCPClient({...})
+model = init_chat_model("openai:gpt-4.1")
+
+bound = bind_mcp_prompt(
+    model,
+    client=client,
+    server_name="math",
+    prompt_name="configure_assistant",
+    arguments={"skills": "arithmetic"},
+)
+# Prefer ainvoke: MCP client I/O is async
+reply = await bound.ainvoke("What is 7 * 8?")
+```
+
+For LangGraph state with extra fields, pass **`arguments_resolver=lambda state: {...}`** so template arguments can depend on `state`.
 
 ## Using with LangGraph API Server
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This library provides a lightweight wrapper that makes [Anthropic Model Context 
 
 - 🛠️ Convert MCP tools into [LangChain tools](https://python.langchain.com/docs/concepts/tools/) that can be used with [LangGraph](https://github.com/langchain-ai/langgraph) agents
 - 📦 A client implementation that allows you to connect to multiple MCP servers and load tools from them
+- 📝 MCP **prompts/list** and **prompts/get**: `MultiServerMCPClient.list_prompts()` discovers prompt templates (metadata); `get_prompt()` loads rendered messages for a chosen template (same split as the [MCP Inspector](https://www.npmjs.com/package/@modelcontextprotocol/inspector) flow)
 
 ## Installation
 

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -14,10 +14,12 @@ from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.tools import BaseTool
 from mcp import ClientSession
+from mcp.types import Prompt
+from typing_extensions import Self
 
 from langchain_mcp_adapters.callbacks import CallbackContext, Callbacks
 from langchain_mcp_adapters.interceptors import ToolCallInterceptor
-from langchain_mcp_adapters.prompts import load_mcp_prompt
+from langchain_mcp_adapters.prompts import list_all_mcp_prompts, load_mcp_prompt
 from langchain_mcp_adapters.resources import load_mcp_resources
 from langchain_mcp_adapters.sessions import (
     Connection,
@@ -45,7 +47,8 @@ ASYNC_CONTEXT_MANAGER_ERROR = (
 class MultiServerMCPClient:
     """Client for connecting to multiple MCP servers.
 
-    Loads LangChain-compatible tools, prompts and resources from MCP servers.
+    Loads LangChain-compatible tools, resources, and MCP prompts
+    (`prompts/list` via `list_prompts`, `prompts/get` via `get_prompt`) from MCP servers.
     """
 
     def __init__(
@@ -206,9 +209,65 @@ class MultiServerMCPClient:
         *,
         arguments: dict[str, Any] | None = None,
     ) -> list[HumanMessage | AIMessage]:
-        """Get a prompt from a given MCP server."""
+        """Fetch rendered prompt messages via MCP `prompts/get`.
+
+        For discovering available prompt templates (names, descriptions, arguments)
+        without loading content, use `list_prompts` (MCP `prompts/list`).
+        """
         async with self.session(server_name) as session:
             return await load_mcp_prompt(session, prompt_name, arguments=arguments)
+
+    async def list_prompts(
+        self,
+        server_name: str | None = None,
+    ) -> list[Prompt] | dict[str, list[Prompt]]:
+        """List prompt template metadata via MCP `prompts/list` (paginated per server).
+
+        This mirrors the MCP Inspector flow: list templates first, then call
+        `get_prompt` for a chosen name. Names are **not** prefixed with the server
+        name; use the dict keys when `server_name` is omitted to namespace by server.
+
+        Args:
+            server_name: If set, list prompts from that server only. If `None`, list
+                from every configured server concurrently and return a mapping
+                ``{server_name: [Prompt, ...], ...}``.
+
+        Returns:
+            A list of `mcp.types.Prompt` when `server_name` is set, or a dict mapping
+            each server name to its list of `Prompt` values when listing all servers.
+
+        Raises:
+            ValueError: If `server_name` is not a configured server.
+
+        !!! note
+
+            A new session is opened for each listing call (same pattern as
+            `get_tools` / `get_resources`).
+
+        """
+        if server_name is not None:
+            if server_name not in self.connections:
+                msg = (
+                    f"Couldn't find a server with name '{server_name}', "
+                    f"expected one of '{list(self.connections.keys())}'"
+                )
+                raise ValueError(msg)
+            async with self.session(server_name) as session:
+                return await list_all_mcp_prompts(session)
+
+        if not self.connections:
+            return {}
+
+        async def _load_prompts_from_server(name: str) -> tuple[str, list[Prompt]]:
+            async with self.session(name) as session:
+                return name, await list_all_mcp_prompts(session)
+
+        load_tasks = [
+            asyncio.create_task(_load_prompts_from_server(name))
+            for name in self.connections
+        ]
+        results = await asyncio.gather(*load_tasks)
+        return dict(results)
 
     async def get_resources(
         self,
@@ -252,7 +311,7 @@ class MultiServerMCPClient:
             all_resources.extend(resources)
         return all_resources
 
-    async def __aenter__(self) -> "MultiServerMCPClient":
+    async def __aenter__(self) -> Self:
         """Async context manager entry point.
 
         Raises:

--- a/langchain_mcp_adapters/langgraph_prompt.py
+++ b/langchain_mcp_adapters/langgraph_prompt.py
@@ -1,0 +1,103 @@
+"""LangGraph helpers for MCP ``prompts/get`` (prompt injection nodes)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from langchain_core.messages import BaseMessage, RemoveMessage
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+Placement = Literal["prepend", "append"]
+
+
+def create_mcp_prompt_injection_node(
+    client: MultiServerMCPClient,
+    server_name: str,
+    prompt_name: str,
+    *,
+    arguments: dict[str, Any] | None = None,
+    arguments_resolver: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
+    placement: Placement = "prepend",
+) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]:
+    """Build an async LangGraph node that fetches MCP prompt content into ``messages``.
+
+    Uses MCP ``prompts/get`` via ``MultiServerMCPClient.get_prompt``. Intended for
+    ``StateGraph`` states whose ``messages`` channel uses ``add_messages`` (e.g.
+    ``MessagesState`` from ``langgraph.graph.message``).
+
+    Args:
+        client: ``MultiServerMCPClient`` instance.
+        server_name: Connection name configured on the client.
+        prompt_name: MCP prompt template name.
+        arguments: Static template arguments. Ignored when ``arguments_resolver`` is
+            set.
+        arguments_resolver: Callable mapping ``state`` to template argument dicts.
+        placement: ``"prepend"`` inserts MCP messages before history (remove-all +
+            replay). ``"append"`` appends MCP messages after existing ones.
+
+    Returns:
+        Async ``node(state) -> {"messages": ...}`` for ``add_node("inject", node)``.
+
+    Raises:
+        ImportError: If ``langgraph`` is not installed.
+
+    !!! example
+
+        ```python
+        from langgraph.graph import END, MessagesState, START, StateGraph
+
+        from langchain_mcp_adapters.client import MultiServerMCPClient
+        from langchain_mcp_adapters.langgraph_prompt import (
+            create_mcp_prompt_injection_node,
+        )
+
+        client = MultiServerMCPClient({...})
+        inject = create_mcp_prompt_injection_node(
+            client,
+            "math",
+            "configure_assistant",
+            arguments={"skills": "algebra"},
+        )
+
+        builder = StateGraph(MessagesState)
+        builder.add_node("mcp_prompt", inject)
+        builder.add_edge(START, "mcp_prompt")
+        builder.add_edge("mcp_prompt", END)
+        graph = builder.compile()
+        ```
+
+    """
+    try:
+        from langgraph.graph.message import REMOVE_ALL_MESSAGES  # noqa: PLC0415
+    except ImportError as e:
+        msg = (
+            "langgraph is required for create_mcp_prompt_injection_node. "
+            "Install with: pip install langgraph"
+        )
+        raise ImportError(msg) from e
+
+    async def mcp_prompt_injection_node(state: dict[str, Any]) -> dict[str, Any]:
+        if arguments_resolver is not None:
+            resolved = arguments_resolver(state)
+        else:
+            resolved = arguments
+        extra = await client.get_prompt(
+            server_name,
+            prompt_name,
+            arguments=resolved,
+        )
+        existing: list[BaseMessage] = list(state.get("messages", []))
+        if placement == "append":
+            return {"messages": extra}
+        prepend_payload: list[BaseMessage] = [
+            RemoveMessage(id=REMOVE_ALL_MESSAGES),
+            *extra,
+            *existing,
+        ]
+        return {"messages": prepend_payload}
+
+    return mcp_prompt_injection_node

--- a/langchain_mcp_adapters/prompt_binder.py
+++ b/langchain_mcp_adapters/prompt_binder.py
@@ -1,0 +1,123 @@
+"""Compose MCP ``prompts/get`` with a chat model like ``bind_tools`` composes tools.
+
+MCP has no protocol equivalent to tool-binding on the model: templates are fetched
+with ``prompts/get`` and become plain messages. This module exposes a **Runnable**
+that prepends those messages then delegates to the model, so you can write
+``bind_mcp_prompt(...)`` in the same spirit as ``model.bind_tools(tools)``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from langchain_core.messages import BaseMessage, convert_to_messages
+from langchain_core.prompt_values import ChatPromptValue, PromptValue
+from langchain_core.runnables import Runnable, RunnableLambda
+
+if TYPE_CHECKING:
+    from langchain_core.language_models.base import LanguageModelInput
+
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+_Out = TypeVar("_Out")
+
+
+def _messages_from_input(model_input: object) -> list[BaseMessage]:
+    """Normalize chat model input to a list of messages."""
+    if isinstance(model_input, dict) and "messages" in model_input:
+        raw = model_input["messages"]
+        return convert_to_messages(raw)
+    if isinstance(model_input, PromptValue):
+        return list(model_input.to_messages())
+    if isinstance(model_input, str):
+        return convert_to_messages([model_input])
+    if isinstance(model_input, BaseMessage):
+        return [model_input]
+    if isinstance(model_input, Sequence):
+        return convert_to_messages(model_input)
+    msg = (
+        "Unsupported input for bind_mcp_prompt: expected str, BaseMessage, "
+        "sequence of messages, dict with 'messages', or PromptValue. "
+        f"Got {type(model_input)!r}."
+    )
+    raise TypeError(msg)
+
+
+def _merge_input_with_messages(
+    model_input: object,
+    messages: list[BaseMessage],
+) -> LanguageModelInput:
+    """Rebuild the same input shape with ``messages`` replaced / inserted."""
+    if isinstance(model_input, dict) and "messages" in model_input:
+        merged_dict = dict(model_input)
+        merged_dict["messages"] = messages
+        return merged_dict
+    if isinstance(model_input, PromptValue):
+        return ChatPromptValue(messages=messages)
+    return messages
+
+
+def bind_mcp_prompt(
+    model: Runnable[LanguageModelInput, _Out],
+    *,
+    client: MultiServerMCPClient,
+    server_name: str,
+    prompt_name: str,
+    arguments: dict[str, Any] | None = None,
+    arguments_resolver: Callable[[object], dict[str, Any] | None] | None = None,
+) -> Runnable[LanguageModelInput, _Out]:
+    """Prepend MCP ``prompts/get`` messages, then run ``model``.
+
+    Mirrors the tools pattern: ``bind_tools`` attaches tool schemas; here we
+    **materialize** MCP prompt messages and prepend them before user / graph
+    messages.
+
+    Args:
+        model: A LangChain chat model runnable (``BaseChatModel`` or bound variant).
+        client: Client used for ``get_prompt`` (MCP ``prompts/get``).
+        server_name: MCP server key in the client configuration.
+        prompt_name: Template name on that server.
+        arguments: Static ``prompts/get`` arguments. Ignored if ``arguments_resolver``
+            is set.
+        arguments_resolver: ``(model_input) -> dict | None`` for per-call arguments
+            (e.g. read fields from a LangGraph state dict).
+
+    Returns:
+        A runnable with the same input and output types as ``model``.
+
+    !!! note
+
+        MCP I/O is async: prefer ``await bound.ainvoke(...)``. Sync ``invoke`` only
+        works if your stack runs async ``RunnableLambda`` correctly.
+
+    !!! example "LangGraph-style state"
+
+        ```python
+        bound = bind_mcp_prompt(
+            model,
+            client=client,
+            server_name="knowledge",
+            prompt_name="classify_intent",
+            arguments_resolver=lambda s: {"domain": s["domain"]},
+        )
+        await bound.ainvoke({"messages": state["messages"], "domain": "legal"})
+        ```
+
+    """
+
+    async def _prepend_prompt(model_input: object) -> LanguageModelInput:
+        if arguments_resolver is not None:
+            resolved = arguments_resolver(model_input)
+        else:
+            resolved = arguments
+        extra = await client.get_prompt(
+            server_name,
+            prompt_name,
+            arguments=resolved,
+        )
+        base = _messages_from_input(model_input)
+        merged = [*extra, *base]
+        return _merge_input_with_messages(model_input, merged)
+
+    return RunnableLambda(_prepend_prompt) | model

--- a/langchain_mcp_adapters/prompts.py
+++ b/langchain_mcp_adapters/prompts.py
@@ -1,14 +1,22 @@
-"""Prompts adapter for converting MCP prompts to LangChain [messages](https://docs.langchain.com/oss/python/langchain/messages).
+"""Prompts adapter for MCP `prompts/list` and `prompts/get`.
 
-This module provides functionality to convert MCP prompt messages into LangChain
-message objects, handling both user and assistant message types.
+Maps MCP prompt operations to LangChain [messages](https://docs.langchain.com/oss/python/langchain/messages):
+
+- `list_all_mcp_prompts` — walks every page of the MCP
+  [`prompts/list`](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#listing-prompts)
+  request (metadata only: names, descriptions, argument schemas).
+- `load_mcp_prompt` — calls MCP
+  [`prompts/get`](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#getting-a-prompt)
+  and converts returned messages to LangChain types.
 """
 
 from typing import Any
 
 from langchain_core.messages import AIMessage, HumanMessage
 from mcp import ClientSession
-from mcp.types import PromptMessage
+from mcp.types import Prompt, PromptMessage
+
+MAX_ITERATIONS = 1000
 
 
 def convert_mcp_prompt_message_to_langchain_message(
@@ -33,6 +41,45 @@ def convert_mcp_prompt_message_to_langchain_message(
 
     msg = f"Unsupported prompt message content type: {message.content.type}"
     raise ValueError(msg)
+
+
+async def list_all_mcp_prompts(session: ClientSession) -> list[Prompt]:
+    """List every prompt template from the server via MCP `prompts/list` (paginated).
+
+    Repeatedly calls `ClientSession.list_prompts` until `nextCursor` is absent,
+    per the MCP pagination rules.
+
+    Args:
+        session: Initialized MCP client session.
+
+    Returns:
+        All `Prompt` metadata entries (no rendered prompt content).
+
+    Raises:
+        RuntimeError: If pagination exceeds `MAX_ITERATIONS`.
+
+    """
+    current_cursor: str | None = None
+    all_prompts: list[Prompt] = []
+    iterations = 0
+
+    while True:
+        iterations += 1
+        if iterations > MAX_ITERATIONS:
+            msg = f"Reached max of {MAX_ITERATIONS} iterations while listing prompts."
+            raise RuntimeError(msg)
+
+        list_prompts_page_result = await session.list_prompts(cursor=current_cursor)
+
+        if list_prompts_page_result.prompts:
+            all_prompts.extend(list_prompts_page_result.prompts)
+
+        if not list_prompts_page_result.nextCursor:
+            break
+
+        current_cursor = list_prompts_page_result.nextCursor
+
+    return all_prompts
 
 
 async def load_mcp_prompt(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ test = [
     "websockets>=15.0.1",
     "pytest-timeout>=2.4.0",
     "dirty-equals>=0.9.0",
+    "langgraph>=1.1.10",
 ]
 
 [project.urls]

--- a/tests/servers/math_server.py
+++ b/tests/servers/math_server.py
@@ -17,12 +17,42 @@ def multiply(a: int, b: int) -> int:
 
 @mcp.prompt()
 def configure_assistant(skills: str) -> list[dict]:
+    """Configure the assistant persona and allowed skills."""
     return [
         {
             "role": "assistant",
             "content": (
                 f"You are a helpful assistant. You have these skills: {skills}. "
                 "Always use only one tool at a time."
+            ),
+        },
+    ]
+
+
+@mcp.prompt()
+def math_problem_solver(problem_type: str) -> list[dict]:
+    """Expert prompt for solving math problems by category."""
+    return [
+        {
+            "role": "assistant",
+            "content": (
+                f"You are a math expert specializing in {problem_type}. "
+                "Provide step-by-step solutions to problems."
+            ),
+        },
+    ]
+
+
+@mcp.prompt()
+def calculation_guide() -> list[dict]:
+    """Static reference for performing calculations safely."""
+    return [
+        {
+            "role": "assistant",
+            "content": (
+                "You are a calculation guide. "
+                "Help users understand how to perform "
+                "mathematical operations correctly."
             ),
         },
     ]

--- a/tests/servers/weather_server.py
+++ b/tests/servers/weather_server.py
@@ -9,6 +9,20 @@ async def get_weather(location: str) -> str:
     return f"It's always sunny in {location}"
 
 
+@mcp.prompt()
+def weather_briefing_style(tone: str) -> list[dict]:
+    """How to phrase weather answers for end users."""
+    return [
+        {
+            "role": "assistant",
+            "content": (
+                f"You report weather in a {tone} tone. "
+                "Keep answers short unless the user asks for detail."
+            ),
+        },
+    ]
+
+
 @mcp.resource("weather://forecast")
 def get_weather_forecast() -> str:
     """Get weather forecast."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ import pytest
 from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage
 from langchain_core.tools import BaseTool
+from mcp.types import Prompt
 
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.sessions import _create_stdio_session
@@ -274,6 +275,99 @@ async def test_get_prompt():
     assert isinstance(messages[0], AIMessage)
     assert "You are a helpful assistant" in messages[0].content
     assert "math, addition, multiplication" in messages[0].content
+
+
+async def test_list_prompts_from_specific_server():
+    """Test MCP prompts/list metadata for one server."""
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+            },
+        },
+    )
+    prompts = await client.list_prompts(server_name="math")
+
+    assert len(prompts) == 3
+    assert all(isinstance(p, Prompt) for p in prompts)
+    by_name = {p.name: p for p in prompts}
+
+    cfg = by_name["configure_assistant"]
+    assert cfg.description is not None
+    assert "Configure the assistant" in cfg.description
+    assert len(cfg.arguments or []) == 1
+    assert cfg.arguments[0].name == "skills"
+    assert cfg.arguments[0].required is True
+
+    solver = by_name["math_problem_solver"]
+    assert solver.description is not None
+    assert "Expert prompt" in solver.description
+    assert len(solver.arguments or []) == 1
+    assert solver.arguments[0].name == "problem_type"
+
+    guide = by_name["calculation_guide"]
+    assert guide.description is not None
+    assert "calculation" in guide.description.lower()
+    assert (guide.arguments or []) == []
+
+
+async def test_list_prompts_from_all_servers():
+    """Test prompts/list across servers returns a namespaced dict."""
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+    weather_server_path = os.path.join(current_dir, "servers/weather_server.py")
+
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+            },
+            "weather": {
+                "command": "python3",
+                "args": [weather_server_path],
+                "transport": "stdio",
+            },
+        },
+    )
+    prompts_by_server = await client.list_prompts()
+
+    assert set(prompts_by_server) == {"math", "weather"}
+    assert len(prompts_by_server["math"]) == 3
+    assert len(prompts_by_server["weather"]) == 1
+    weather_names = {p.name for p in prompts_by_server["weather"]}
+    assert weather_names == {"weather_briefing_style"}
+
+
+async def test_list_prompts_invalid_server():
+    """Test list_prompts raises for unknown server."""
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="nonexistent_server"):
+        await client.list_prompts("nonexistent_server")
+
+
+async def test_list_prompts_empty_connections_returns_empty_dict():
+    """When no servers are configured, list all prompts yields an empty mapping."""
+    client = MultiServerMCPClient({})
+    assert await client.list_prompts() == {}
 
 
 async def test_get_resources_from_all_servers():

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -3,6 +3,7 @@ def test_import() -> None:
     from langchain_mcp_adapters import (  # noqa: F401, PLC0415
         callbacks,
         client,
+        langgraph_prompt,
         prompt_binder,
         prompts,
         resources,

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -3,6 +3,7 @@ def test_import() -> None:
     from langchain_mcp_adapters import (  # noqa: F401, PLC0415
         callbacks,
         client,
+        prompt_binder,
         prompts,
         resources,
         tools,

--- a/tests/test_langgraph_prompt.py
+++ b/tests/test_langgraph_prompt.py
@@ -1,0 +1,96 @@
+import os
+from pathlib import Path
+from typing import Annotated, NotRequired
+
+import pytest
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import MessagesState, add_messages
+from typing_extensions import TypedDict
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.langgraph_prompt import create_mcp_prompt_injection_node
+
+
+class MessagesAndDomainState(TypedDict):
+    messages: Annotated[list[AnyMessage], add_messages]
+    domain: NotRequired[str]
+
+
+@pytest.fixture
+def math_client() -> MultiServerMCPClient:
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+    return MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+            },
+        },
+    )
+
+
+async def test_injection_prepend_mcp_before_user(math_client: MultiServerMCPClient):
+    inject = create_mcp_prompt_injection_node(
+        math_client,
+        "math",
+        "configure_assistant",
+        arguments={"skills": "unit-test"},
+        placement="prepend",
+    )
+    builder = StateGraph(MessagesState)
+    builder.add_node("mcp_prompt", inject)
+    builder.add_edge(START, "mcp_prompt")
+    builder.add_edge("mcp_prompt", END)
+    graph = builder.compile()
+
+    out = await graph.ainvoke({"messages": [HumanMessage(content="hello")]})
+    msgs = out["messages"]
+    assert len(msgs) == 2
+    assert isinstance(msgs[0], AIMessage)
+    assert "unit-test" in (msgs[0].content or "")
+    assert isinstance(msgs[1], HumanMessage)
+    assert msgs[1].content == "hello"
+
+
+async def test_injection_node_append(math_client: MultiServerMCPClient):
+    inject = create_mcp_prompt_injection_node(
+        math_client,
+        "math",
+        "calculation_guide",
+        placement="append",
+    )
+    builder = StateGraph(MessagesState)
+    builder.add_node("mcp_prompt", inject)
+    builder.add_edge(START, "mcp_prompt")
+    builder.add_edge("mcp_prompt", END)
+    graph = builder.compile()
+
+    out = await graph.ainvoke({"messages": [HumanMessage(content="first")]})
+    msgs = out["messages"]
+    assert len(msgs) == 2
+    assert isinstance(msgs[0], HumanMessage)
+    assert msgs[0].content == "first"
+    assert isinstance(msgs[1], AIMessage)
+    assert "calculation" in (msgs[1].content or "").lower()
+
+
+async def test_injection_node_arguments_resolver(math_client: MultiServerMCPClient):
+    inject = create_mcp_prompt_injection_node(
+        math_client,
+        "math",
+        "configure_assistant",
+        arguments_resolver=lambda s: {"skills": s["domain"]},
+    )
+    builder = StateGraph(MessagesAndDomainState)
+    builder.add_node("mcp_prompt", inject)
+    builder.add_edge(START, "mcp_prompt")
+    builder.add_edge("mcp_prompt", END)
+    graph = builder.compile()
+
+    out = await graph.ainvoke(
+        {"messages": [HumanMessage(content="x")], "domain": "resolver-skills"},
+    )
+    assert "resolver-skills" in (out["messages"][0].content or "")

--- a/tests/test_prompt_binder.py
+++ b/tests/test_prompt_binder.py
@@ -1,0 +1,118 @@
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.runnables import RunnableLambda
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.prompt_binder import bind_mcp_prompt
+
+
+async def _fake_model(model_input: object) -> AIMessage:
+    if isinstance(model_input, list):
+        msgs = model_input
+    elif isinstance(model_input, dict) and "messages" in model_input:
+        msgs = model_input["messages"]
+    else:
+        msgs = []
+    return AIMessage(content=f"count={len(msgs)}")
+
+
+async def test_bind_mcp_prompt_prepends_messages_list_input():
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+            },
+        },
+    )
+    model = RunnableLambda(_fake_model)
+    bound = bind_mcp_prompt(
+        model,
+        client=client,
+        server_name="math",
+        prompt_name="configure_assistant",
+        arguments={"skills": "algebra"},
+    )
+    out = await bound.ainvoke([HumanMessage(content="solve 2+2")])
+    assert isinstance(out, AIMessage)
+    assert out.content == "count=2"
+
+
+async def test_bind_mcp_prompt_dict_state_messages():
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+            },
+        },
+    )
+    model = RunnableLambda(_fake_model)
+    bound = bind_mcp_prompt(
+        model,
+        client=client,
+        server_name="math",
+        prompt_name="calculation_guide",
+        arguments=None,
+    )
+    state = {"messages": [HumanMessage(content="hi")], "extra": 1}
+    out = await bound.ainvoke(state)
+    assert isinstance(out, AIMessage)
+    assert out.content == "count=2"
+    assert state["extra"] == 1
+
+
+async def test_bind_mcp_prompt_arguments_resolver():
+    current_dir = Path(__file__).parent
+    math_server_path = os.path.join(current_dir, "servers/math_server.py")
+    client = MultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": [math_server_path],
+                "transport": "stdio",
+            },
+        },
+    )
+    model = RunnableLambda(_fake_model)
+    bound = bind_mcp_prompt(
+        model,
+        client=client,
+        server_name="math",
+        prompt_name="configure_assistant",
+        arguments_resolver=lambda s: {"skills": s["skills"]},
+    )
+    out = await bound.ainvoke(
+        {"messages": [HumanMessage(content="x")], "skills": "geometry"},
+    )
+    assert isinstance(out, AIMessage)
+    assert out.content == "count=2"
+
+
+async def test_bind_mcp_prompt_uses_mock_client_for_resolver_priority():
+    client = AsyncMock(spec=MultiServerMCPClient)
+    client.get_prompt = AsyncMock(
+        return_value=[AIMessage(content="from mcp")],
+    )
+    model = RunnableLambda(_fake_model)
+    bound = bind_mcp_prompt(
+        model,
+        client=client,
+        server_name="srv",
+        prompt_name="p",
+        arguments={"a": 1},
+        arguments_resolver=lambda _: {"skills": "from_resolver"},
+    )
+    await bound.ainvoke([HumanMessage(content="u")])
+    client.get_prompt.assert_awaited_once()
+    call_kw = client.get_prompt.await_args
+    assert call_kw.kwargs["arguments"] == {"skills": "from_resolver"}

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -5,6 +5,8 @@ from langchain_core.messages import AIMessage, HumanMessage
 from mcp.types import (
     EmbeddedResource,
     ImageContent,
+    ListPromptsResult,
+    Prompt,
     PromptMessage,
     TextContent,
     TextResourceContents,
@@ -12,6 +14,7 @@ from mcp.types import (
 
 from langchain_mcp_adapters.prompts import (
     convert_mcp_prompt_message_to_langchain_message,
+    list_all_mcp_prompts,
     load_mcp_prompt,
 )
 
@@ -80,3 +83,23 @@ async def test_load_mcp_prompt():
     assert result[0].content == "Hello"
     assert isinstance(result[1], AIMessage)
     assert result[1].content == "Hi"
+
+
+async def test_list_all_mcp_prompts_paginates():
+    """Exhaust MCP prompts/list pagination (nextCursor)."""
+    session = AsyncMock()
+    first = Prompt(name="page_a", description=None, arguments=[])
+    second = Prompt(name="page_b", description=None, arguments=[])
+    session.list_prompts = AsyncMock(
+        side_effect=[
+            ListPromptsResult(prompts=[first], nextCursor="cursor-2"),
+            ListPromptsResult(prompts=[second], nextCursor=None),
+        ],
+    )
+
+    result = await list_all_mcp_prompts(session)
+
+    assert [p.name for p in result] == ["page_a", "page_b"]
+    assert session.list_prompts.await_count == 2
+    session.list_prompts.assert_any_await(cursor=None)
+    session.list_prompts.assert_awaited_with(cursor="cursor-2")

--- a/uv.lock
+++ b/uv.lock
@@ -429,10 +429,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.28"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -441,9 +442,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/a4/317a1a3ac1df33a64adb3670bf88bbe3b3d5baa274db6863a979db472897/langchain_core-1.2.28.tar.gz", hash = "sha256:271a3d8bd618f795fdeba112b0753980457fc90537c46a0c11998516a74dc2cb", size = 846119, upload-time = "2026-04-08T18:19:34.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/03/7219502e8ca728d65eb44d7a3eb60239230742a70dbfc9241b9bfd61c4ab/langchain_core-1.3.2.tar.gz", hash = "sha256:fd7a50b2f28ba561fd9d7f5d2760bc9e06cf00cdf820a3ccafe88a94ffa8d5b7", size = 911813, upload-time = "2026-04-24T15:49:23.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/92/32f785f077c7e898da97064f113c73fbd9ad55d1e2169cf3a391b183dedb/langchain_core-1.2.28-py3-none-any.whl", hash = "sha256:80764232581eaf8057bcefa71dbf8adc1f6a28d257ebd8b95ba9b8b452e8c6ac", size = 508727, upload-time = "2026-04-08T18:19:32.823Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d5/8fa4431007cbb7cfed7590f4d6a5dea3ad724f4174d248f6642ef5ce7d05/langchain_core-1.3.2-py3-none-any.whl", hash = "sha256:d44a66127f9f8db735bdfd0ab9661bccb47a97113cfd3f2d89c74864422b7274", size = 542390, upload-time = "2026-04-24T15:49:21.991Z" },
 ]
 
 [[package]]
@@ -462,6 +463,7 @@ integration = [
 ]
 test = [
     { name = "dirty-equals" },
+    { name = "langgraph" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -483,6 +485,7 @@ requires-dist = [
 integration = [{ name = "langchain", specifier = ">=1.0.8" }]
 test = [
     { name = "dirty-equals", specifier = ">=0.9.0" },
+    { name = "langgraph", specifier = ">=1.1.10" },
     { name = "mypy", specifier = ">=1.8.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
@@ -494,8 +497,20 @@ test = [
 ]
 
 [[package]]
+name = "langchain-protocol"
+version = "0.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/51/1157009b6f94e6e58be58fa8b620187d657909a8b36a6bf5b0c52a2711f6/langchain_protocol-0.0.12.tar.gz", hash = "sha256:5e14c434290a705c9510fdb1a83ecf7561a5e6e0dfd053930ade80dba069269f", size = 6408, upload-time = "2026-04-25T01:05:01.489Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/82/3431e3061c917439589fa88a6b23c9bc0e154cba0f05d2e895a68c76ff74/langchain_protocol-0.0.12-py3-none-any.whl", hash = "sha256:402b61f42d4139692528cf37226c367bb6efc8ff8165b29380accb0abfece7b2", size = 6639, upload-time = "2026-04-25T01:05:00.487Z" },
+]
+
+[[package]]
 name = "langgraph"
-version = "1.1.3"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -505,9 +520,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/b2/e7db624e8b0ee063ecfbf7acc09467c0836a05914a78e819dfb3744a0fac/langgraph-1.1.3.tar.gz", hash = "sha256:ee496c297a9c93b38d8560be15cbb918110f49077d83abd14976cb13ac3b3370", size = 545120, upload-time = "2026-03-18T23:42:58.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/f7/221cc479e95e03e260496616e5ce6fb50c1ea01472e3a5bc481a9b8a2f83/langgraph-1.1.3-py3-none-any.whl", hash = "sha256:57cd6964ebab41cbd211f222293a2352404e55f8b2312cecde05e8753739b546", size = 168149, upload-time = "2026-03-18T23:42:56.967Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
 ]
 
 [[package]]
@@ -525,15 +540,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.8"
+version = "1.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/06/dd61a5c2dce009d1b03b1d56f2a85b3127659fdddf5b3be5d8f1d60820fb/langgraph_prebuilt-1.0.8.tar.gz", hash = "sha256:0cd3cf5473ced8a6cd687cc5294e08d3de57529d8dd14fdc6ae4899549efcf69", size = 164442, upload-time = "2026-02-19T18:14:39.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/8b/5fff4c63bbfef1475d577e13f5970f91955a4069d8dc4adbaeef92f36732/langgraph_prebuilt-1.0.12.tar.gz", hash = "sha256:edcb11ff29996def816243f267fb2c85c0a2e4fb618c275f3d238aee8dd6a5ec", size = 172831, upload-time = "2026-04-27T17:14:27.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/41/ec966424ad3f2ed3996d24079d3342c8cd6c0bd0653c12b2a917a685ec6c/langgraph_prebuilt-1.0.8-py3-none-any.whl", hash = "sha256:d16a731e591ba4470f3e313a319c7eee7dbc40895bcf15c821f985a3522a7ce0", size = 35648, upload-time = "2026-02-19T18:14:37.611Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/1e6e6fd478a1b1e643de03505570103dcb89c57c429c0fd3084d521e522e/langgraph_prebuilt-1.0.12-py3-none-any.whl", hash = "sha256:ab83822d2724d434d3536dc127b86c7d16fe3fb8dc02a89a683bc77b2e55f6e9", size = 37195, upload-time = "2026-04-27T17:14:25.788Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

### `list_prompts()` / `list_all_mcp_prompts()`

- **`MultiServerMCPClient.list_prompts()`** aligned with MCP **`prompts/list`**: discover prompt template metadata (name, description, argument schema) without loading rendered content. Pagination (`nextCursor`) is handled automatically via **`list_all_mcp_prompts()`** in `langchain_mcp_adapters.prompts`.
- **`server_name` set**: returns `list[mcp.types.Prompt]` for that server.
- **`server_name` is `None`**: returns `dict[str, list[Prompt]]` keyed by configured server name (prompt **names** are not prefixed—use dict keys for the server dimension).

**`get_prompt()`** is unchanged in behavior; its docstring states it maps to MCP **`prompts/get`**, and points to `list_prompts` for discovery (same mental model as the MCP Inspector: list, then get).

### `bind_mcp_prompt` (`langchain_mcp_adapters.prompt_binder.py`)

- Runnable **`bind_mcp_prompt(model, client=..., ...)`** = prepend MCP **`prompts/get`** messages, then invoke the chat model (ergonomics similar to chaining after `bind_tools`, without being a protocol-level “bind” on the LLM).
- Optional **`arguments_resolver(state)`** for LangGraph-style dict state.

### `create_mcp_prompt_injection_node` (`langchain_mcp_adapters.langgraph_prompt.py`)

- LangGraph node factory: updates **`messages`** for **`add_messages`** / **`MessagesState`**.
- **`placement="prepend"`** (default): **`RemoveMessage(REMOVE_ALL_MESSAGES)`** + replay so MCP messages appear before history.
- **`placement="append"`**: append MCP messages after existing ones.
- **`langgraph>=1.1.10`** added to **`[dependency-groups] test`** only (not a runtime dependency of the package); README documents `pip install langgraph` for app use.

## Motivation

Closes the gap described in langchain-ai/langchain#40490: agents can discover prompts at runtime instead of hardcoding names; adds ergonomic composition with LangChain / LangGraph.

## Relation to langchain-ai/langchain-mcp-adapters#377

[#377](https://github.com/langchain-ai/langchain-mcp-adapters/pull/377) added a minimal `get_prompts(server_name)` without multi-server aggregation, automatic pagination, or a namespaced “all servers” return shape. This PR uses **`list_prompts`** to mirror MCP `prompts/list` and contrast with **`get_prompt`** (`prompts/get`). Happy to align naming (e.g. alias `get_prompts` → `list_prompts`) or consolidate with langchain-ai/langchain-mcp-adapters#377 per maintainers.

## Follow-ups (still out of scope)

- `notifications/prompts/list_changed` (long-lived session / listener design)

Fixes langchain-ai/langchain#40490
