### PR TITLE
Enhance LongLivedMultiServerMCPClient with session management and health checks

### DIFF
--- a/langchain_mcp_adapters/__init__.py
+++ b/langchain_mcp_adapters/__init__.py
@@ -4,3 +4,13 @@ This package provides adapters to connect MCP (Model Context Protocol) servers
 with LangChain applications, converting MCP tools, prompts, and resources into
 LangChain-compatible formats.
 """
+
+from langchain_mcp_adapters.client import (
+    LongLivedMultiServerMCPClient,
+    MultiServerMCPClient,
+)
+
+__all__ = [
+    "LongLivedMultiServerMCPClient",
+    "MultiServerMCPClient",
+]

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -6,6 +6,7 @@ to multiple MCP servers and loading tools, prompts, and resources from them.
 
 import asyncio
 from collections.abc import AsyncIterator
+from contextlib import AbstractAsyncContextManager
 from contextlib import asynccontextmanager
 from types import TracebackType
 from typing import Any
@@ -279,8 +280,188 @@ class MultiServerMCPClient:
         raise NotImplementedError(ASYNC_CONTEXT_MANAGER_ERROR)
 
 
+class LongLivedMultiServerMCPClient(MultiServerMCPClient):
+    """A `MultiServerMCPClient` variant that keeps sessions alive across tool calls.
+
+    Use this class as an async context manager:
+
+    ```python
+    async with LongLivedMultiServerMCPClient(connections) as client:
+        tools = await client.get_tools()
+    ```
+
+    In this mode, tools loaded by `get_tools()` will reuse long-lived server sessions.
+    """
+
+    def __init__(
+        self,
+        connections: dict[str, Connection] | None = None,
+        *,
+        callbacks: Callbacks | None = None,
+        tool_interceptors: list[ToolCallInterceptor] | None = None,
+        tool_name_prefix: bool = False,
+    ) -> None:
+        super().__init__(
+            connections=connections,
+            callbacks=callbacks,
+            tool_interceptors=tool_interceptors,
+            tool_name_prefix=tool_name_prefix,
+        )
+        self.sessions: dict[str, ClientSession] = {}
+        self._session_cms: dict[str, AbstractAsyncContextManager[ClientSession]] = {}
+
+    async def start(self) -> None:
+        """Start long-lived sessions for all configured servers."""
+        for server_name in self.connections:
+            if server_name not in self.sessions:
+                await self._create_session_for_server(server_name)
+
+    async def _create_session_for_server(self, server_name: str) -> None:
+        cm = self.session(server_name, auto_initialize=True)
+        session = await cm.__aenter__()
+        self.sessions[server_name] = session
+        self._session_cms[server_name] = cm
+
+    async def stop(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
+    ) -> None:
+        """Close all long-lived sessions."""
+        for cm in self._session_cms.values():
+            await cm.__aexit__(exc_type, exc_val, exc_tb)
+        self.sessions.clear()
+        self._session_cms.clear()
+
+    async def get_tools(self, *, server_name: str | None = None) -> list[BaseTool]:
+        """Get tools, preferring long-lived sessions when available."""
+        if server_name is not None:
+            if server_name not in self.connections:
+                msg = (
+                    f"Couldn't find a server with name '{server_name}', "
+                    f"expected one of '{list(self.connections.keys())}'"
+                )
+                raise ValueError(msg)
+
+            session = self.sessions.get(server_name)
+            if session is not None:
+                return await load_mcp_tools(
+                    session,
+                    callbacks=self.callbacks,
+                    server_name=server_name,
+                    tool_interceptors=self.tool_interceptors,
+                    tool_name_prefix=self.tool_name_prefix,
+                )
+
+            return await load_mcp_tools(
+                None,
+                connection=self.connections[server_name],
+                callbacks=self.callbacks,
+                server_name=server_name,
+                tool_interceptors=self.tool_interceptors,
+                tool_name_prefix=self.tool_name_prefix,
+            )
+
+        all_tools: list[BaseTool] = []
+        load_mcp_tool_tasks = []
+        for name, connection in self.connections.items():
+            session = self.sessions.get(name)
+            load_mcp_tool_task = asyncio.create_task(
+                load_mcp_tools(
+                    session,
+                    connection=None if session is not None else connection,
+                    callbacks=self.callbacks,
+                    server_name=name,
+                    tool_interceptors=self.tool_interceptors,
+                    tool_name_prefix=self.tool_name_prefix,
+                )
+            )
+            load_mcp_tool_tasks.append(load_mcp_tool_task)
+        tools_list = await asyncio.gather(*load_mcp_tool_tasks)
+        for tools in tools_list:
+            all_tools.extend(tools)
+        return all_tools
+
+    async def get_prompt(
+        self,
+        server_name: str,
+        prompt_name: str,
+        *,
+        arguments: dict[str, Any] | None = None,
+    ) -> list[HumanMessage | AIMessage]:
+        """Get a prompt, preferring long-lived sessions when available."""
+        if server_name not in self.connections:
+            msg = (
+                f"Couldn't find a server with name '{server_name}', "
+                f"expected one of '{list(self.connections.keys())}'"
+            )
+            raise ValueError(msg)
+
+        session = self.sessions.get(server_name)
+        if session is not None:
+            return await load_mcp_prompt(session, prompt_name, arguments=arguments)
+
+        async with self.session(server_name) as ephemeral_session:
+            return await load_mcp_prompt(
+                ephemeral_session, prompt_name, arguments=arguments
+            )
+
+    async def get_resources(
+        self,
+        server_name: str | None = None,
+        *,
+        uris: str | list[str] | None = None,
+    ) -> list[Blob]:
+        """Get resources, preferring long-lived sessions when available."""
+        if server_name is not None:
+            if server_name not in self.connections:
+                msg = (
+                    f"Couldn't find a server with name '{server_name}', "
+                    f"expected one of '{list(self.connections.keys())}'"
+                )
+                raise ValueError(msg)
+
+            session = self.sessions.get(server_name)
+            if session is not None:
+                return await load_mcp_resources(session, uris=uris)
+
+            async with self.session(server_name) as ephemeral_session:
+                return await load_mcp_resources(ephemeral_session, uris=uris)
+
+        async def _load_resources_from_server(name: str) -> list[Blob]:
+            session = self.sessions.get(name)
+            if session is not None:
+                return await load_mcp_resources(session, uris=uris)
+            async with self.session(name) as ephemeral_session:
+                return await load_mcp_resources(ephemeral_session, uris=uris)
+
+        all_resources: list[Blob] = []
+        load_tasks = [
+            asyncio.create_task(_load_resources_from_server(name))
+            for name in self.connections
+        ]
+        resources_list = await asyncio.gather(*load_tasks)
+        for resources in resources_list:
+            all_resources.extend(resources)
+        return all_resources
+
+    async def __aenter__(self) -> "LongLivedMultiServerMCPClient":
+        await self.start()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        await self.stop(exc_type, exc_val, exc_tb)
+
+
 __all__ = [
     "Callbacks",
+    "LongLivedMultiServerMCPClient",
     "McpHttpClientFactory",
     "MultiServerMCPClient",
     "SSEConnection",

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -5,9 +5,9 @@ to multiple MCP servers and loading tools, prompts, and resources from them.
 """
 
 import asyncio
+import time
 from collections.abc import AsyncIterator
-from contextlib import AsyncExitStack
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from types import TracebackType
 from typing import Any
 
@@ -300,7 +300,22 @@ class LongLivedMultiServerMCPClient(MultiServerMCPClient):
         callbacks: Callbacks | None = None,
         tool_interceptors: list[ToolCallInterceptor] | None = None,
         tool_name_prefix: bool = False,
+        health_check_interval: float | None = None,
+        health_check_timeout: float = 5.0,
     ) -> None:
+        """Initialize a long-lived MCP client with optional health-check config.
+
+        Args:
+            connections: Server connection configurations.
+            callbacks: Optional callbacks for notifications and events.
+            tool_interceptors: Optional tool call interceptors.
+            tool_name_prefix: Prefix tool names with the server name.
+            health_check_interval: Debounce window in seconds for
+                ``sessions_healthy()``. ``None`` (default) means ping on every
+                call.
+            health_check_timeout: Maximum seconds to wait for ping responses
+                in ``health_check()``. Defaults to ``5.0``.
+        """
         super().__init__(
             connections=connections,
             callbacks=callbacks,
@@ -309,6 +324,9 @@ class LongLivedMultiServerMCPClient(MultiServerMCPClient):
         )
         self.sessions: dict[str, ClientSession] = {}
         self._session_stack: AsyncExitStack | None = None
+        self._health_check_interval = health_check_interval
+        self._health_check_timeout = health_check_timeout
+        self._last_healthy_ping: float = 0.0
 
     def _validate_server_name(self, server_name: str) -> None:
         if server_name not in self.connections:
@@ -337,6 +355,7 @@ class LongLivedMultiServerMCPClient(MultiServerMCPClient):
 
         self._session_stack = stack
         self.sessions = sessions
+        self._last_healthy_ping = time.monotonic()
 
     async def stop(
         self,
@@ -441,6 +460,84 @@ class LongLivedMultiServerMCPClient(MultiServerMCPClient):
         for resources in resources_list:
             all_resources.extend(resources)
         return all_resources
+
+    async def health_check(
+        self, timeout: float | None = None
+    ) -> dict[str, bool]:
+        """Ping all active sessions and return per-server health status.
+
+        Uses the MCP protocol's ``send_ping()`` to verify each session is
+        still alive.  Returns a dict mapping server names to health status
+        (``True`` = healthy, ``False`` = dead / timed-out).
+
+        Args:
+            timeout: Maximum seconds to wait for all pings to complete.
+                Defaults to the instance's ``health_check_timeout``.
+                Set to ``None`` to wait indefinitely.
+
+        Returns:
+            Dict mapping server name to health status.  Servers with no
+            active session are reported as ``False``.
+        """
+        _timeout = timeout if timeout is not None else self._health_check_timeout
+        results: dict[str, bool] = {}
+        if not self.sessions:
+            return results
+
+        async def _ping_one(
+            name: str, session: ClientSession
+        ) -> tuple[str, bool]:
+            try:
+                await session.send_ping()
+            except Exception:  # noqa: BLE001
+                return (name, False)
+            else:
+                return (name, True)
+
+        try:
+            async with asyncio.timeout(_timeout):
+                pairs = await asyncio.gather(
+                    *(
+                        _ping_one(name, session)
+                        for name, session in self.sessions.items()
+                    )
+                )
+                results = dict(pairs)
+        except TimeoutError:
+            for name in self.sessions:
+                if name not in results:
+                    results[name] = False
+        return results
+
+    async def sessions_healthy(self) -> bool:
+        """Check whether all active MCP sessions are still alive.
+
+        Uses the debounce interval configured via ``health_check_interval``
+        to avoid redundant pings under concurrent load.  If the interval
+        has not elapsed since the last successful check, returns ``True``
+        immediately without sending any network traffic.
+
+        When ``health_check_interval`` is ``None`` (the default), pings
+        on every call.
+
+        Returns:
+            ``True`` if all sessions responded to ping (or were checked
+            recently within the debounce window).  ``False`` if any
+            session failed or timed out.
+        """
+        if not self.sessions:
+            return True
+
+        if self._health_check_interval is not None and (
+            time.monotonic() - self._last_healthy_ping
+        ) < self._health_check_interval:
+            return True
+
+        status = await self.health_check()
+        all_healthy = all(status.values())
+        if all_healthy:
+            self._last_healthy_ping = time.monotonic()
+        return all_healthy
 
     async def __aenter__(self) -> "LongLivedMultiServerMCPClient":
         await self.start()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -381,6 +381,52 @@ async def test_long_lived_client_uses_persistent_session_for_get_resources(
     assert resources == expected_resources
 
 
+async def test_long_lived_client_start_cleans_up_on_partial_failure(monkeypatch):
+    client = LongLivedMultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": ["unused"],
+                "transport": "stdio",
+            },
+            "weather": {
+                "command": "python3",
+                "args": ["unused"],
+                "transport": "stdio",
+            },
+        }
+    )
+
+    events: list[str] = []
+
+    class FakeCM:
+        def __init__(self, name: str, *, fail_enter: bool = False) -> None:
+            self.name = name
+            self.fail_enter = fail_enter
+
+        async def __aenter__(self):
+            events.append(f"enter:{self.name}")
+            if self.fail_enter:
+                raise RuntimeError("startup failure")
+            return AsyncMock()
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            events.append(f"exit:{self.name}")
+
+    def fake_session(server_name: str, *, auto_initialize: bool = True):
+        assert auto_initialize is True
+        return FakeCM(server_name, fail_enter=(server_name == "weather"))
+
+    monkeypatch.setattr(client, "session", fake_session)
+
+    with pytest.raises(RuntimeError, match="startup failure"):
+        await client.start()
+
+    assert events == ["enter:math", "enter:weather", "exit:math"]
+    assert client.sessions == {}
+    assert client._session_stack is None
+
+
 async def test_get_resources_from_all_servers():
     """Test that get_resources loads resources from all servers."""
     current_dir = Path(__file__).parent

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,7 +10,10 @@ from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage
 from langchain_core.tools import BaseTool
 
-from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.client import (
+    LongLivedMultiServerMCPClient,
+    MultiServerMCPClient,
+)
 from langchain_mcp_adapters.sessions import _create_stdio_session
 from langchain_mcp_adapters.tools import load_mcp_tools
 from tests.utils import IsLangChainID
@@ -274,6 +277,108 @@ async def test_get_prompt():
     assert isinstance(messages[0], AIMessage)
     assert "You are a helpful assistant" in messages[0].content
     assert "math, addition, multiplication" in messages[0].content
+
+
+async def test_long_lived_client_uses_persistent_session_for_load_mcp_tools(
+    monkeypatch,
+):
+    """Verify get_tools() uses the already-open session with load_mcp_tools()."""
+    client = LongLivedMultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": ["unused"],
+                "transport": "stdio",
+            }
+        }
+    )
+    persistent_session = AsyncMock()
+    client.sessions["math"] = persistent_session
+
+    fake_tool = AsyncMock()
+
+    async def fake_load_mcp_tools(session, **kwargs):
+        assert session is persistent_session
+        assert kwargs["server_name"] == "math"
+        assert kwargs["callbacks"] is client.callbacks
+        assert kwargs["tool_name_prefix"] is False
+        return [fake_tool]
+
+    monkeypatch.setattr(
+        "langchain_mcp_adapters.client.load_mcp_tools",
+        fake_load_mcp_tools,
+    )
+
+    tools = await client.get_tools(server_name="math")
+    assert tools == [fake_tool]
+
+
+async def test_long_lived_client_uses_persistent_session_for_get_prompt(monkeypatch):
+    client = LongLivedMultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": ["unused"],
+                "transport": "stdio",
+            }
+        }
+    )
+    persistent_session = AsyncMock()
+    client.sessions["math"] = persistent_session
+
+    expected_messages = [AIMessage(content="ok")]
+
+    async def fake_load_mcp_prompt(session, prompt_name, arguments=None):
+        assert session is persistent_session
+        assert prompt_name == "configure_assistant"
+        assert arguments == {"skills": "math"}
+        return expected_messages
+
+    monkeypatch.setattr(
+        "langchain_mcp_adapters.client.load_mcp_prompt",
+        fake_load_mcp_prompt,
+    )
+
+    messages = await client.get_prompt(
+        "math",
+        "configure_assistant",
+        arguments={"skills": "math"},
+    )
+    assert messages == expected_messages
+
+
+async def test_long_lived_client_uses_persistent_session_for_get_resources(
+    monkeypatch,
+):
+    client = LongLivedMultiServerMCPClient(
+        {
+            "math": {
+                "command": "python3",
+                "args": ["unused"],
+                "transport": "stdio",
+            }
+        }
+    )
+    persistent_session = AsyncMock()
+    client.sessions["math"] = persistent_session
+
+    expected_resources = [Blob(data="E = mc^2", mimetype="text/plain", metadata={})]
+
+    async def fake_load_mcp_resources(session, uris=None):
+        assert session is persistent_session
+        assert uris == "math://formulas"
+        return expected_resources
+
+    monkeypatch.setattr(
+        "langchain_mcp_adapters.client.load_mcp_resources",
+        fake_load_mcp_resources,
+    )
+
+    resources = await client.get_resources(
+        server_name="math",
+        uris="math://formulas",
+    )
+    assert resources == expected_resources
 
 
 async def test_get_resources_from_all_servers():

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -2,8 +2,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock
 
-import httpx
-from anyio import BrokenResourceError, ClosedResourceError
+from anyio import ClosedResourceError
 
 from langchain_mcp_adapters.client import LongLivedMultiServerMCPClient
 
@@ -54,33 +53,6 @@ class TestHealthCheck:
 
         result = await client.health_check(timeout=0.1)
         assert result == {"slow_server": False}
-
-    async def test_broken_resource_error_returns_false(self):
-        client = _make_client()
-        broken = MagicMock()
-        broken.send_ping = AsyncMock(side_effect=BrokenResourceError())
-        client.sessions = {"broken": broken}
-
-        result = await client.health_check()
-        assert result == {"broken": False}
-
-    async def test_httpx_transport_error_returns_false(self):
-        client = _make_client()
-        http_dead = MagicMock()
-        http_dead.send_ping = AsyncMock(side_effect=httpx.ConnectError("refused"))
-        client.sessions = {"http_dead": http_dead}
-
-        result = await client.health_check()
-        assert result == {"http_dead": False}
-
-    async def test_uses_instance_timeout_by_default(self):
-        client = _make_client(health_check_timeout=1.0)
-        fast = MagicMock()
-        fast.send_ping = AsyncMock(return_value=None)
-        client.sessions = {"fast": fast}
-
-        result = await client.health_check()
-        assert result == {"fast": True}
 
     async def test_timeout_arg_overrides_instance_default(self):
         client = _make_client(health_check_timeout=60.0)
@@ -167,17 +139,6 @@ class TestSessionsHealthy:
 
         assert await client.sessions_healthy() is False
         assert client._last_healthy_ping == 0.0
-
-    async def test_healthy_updates_last_ping(self):
-        client = _make_client(health_check_interval=30.0)
-        s1 = MagicMock()
-        s1.send_ping = AsyncMock(return_value=None)
-        client.sessions = {"server_a": s1}
-
-        assert client._last_healthy_ping == 0.0
-        assert await client.sessions_healthy() is True
-        assert client._last_healthy_ping > 0.0
-
 
 class TestStartResetsLastHealthyPing:
     """Verify that start() resets _last_healthy_ping after opening sessions."""

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,207 @@
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+from anyio import BrokenResourceError, ClosedResourceError
+
+from langchain_mcp_adapters.client import LongLivedMultiServerMCPClient
+
+
+def _make_client(**kwargs: object) -> LongLivedMultiServerMCPClient:
+    return LongLivedMultiServerMCPClient(connections={}, **kwargs)  # type: ignore[arg-type]
+
+
+class TestHealthCheck:
+    """Tests for LongLivedMultiServerMCPClient.health_check() — raw ping API."""
+
+    async def test_healthy_sessions_return_true(self):
+        client = _make_client()
+        s1, s2 = MagicMock(), MagicMock()
+        s1.send_ping = AsyncMock(return_value=None)
+        s2.send_ping = AsyncMock(return_value=None)
+        client.sessions = {"server_a": s1, "server_b": s2}
+
+        result = await client.health_check()
+        assert result == {"server_a": True, "server_b": True}
+
+    async def test_dead_session_returns_false(self):
+        client = _make_client()
+        healthy = MagicMock()
+        healthy.send_ping = AsyncMock(return_value=None)
+        dead = MagicMock()
+        dead.send_ping = AsyncMock(side_effect=ClosedResourceError())
+        client.sessions = {"alive": healthy, "dead_server": dead}
+
+        result = await client.health_check()
+        assert result == {"alive": True, "dead_server": False}
+
+    async def test_empty_sessions_returns_empty_dict(self):
+        client = _make_client()
+        client.sessions = {}
+        result = await client.health_check()
+        assert result == {}
+
+    async def test_timeout_marks_slow_sessions_unhealthy(self):
+        client = _make_client()
+        slow = MagicMock()
+
+        async def _slow_ping() -> None:
+            await asyncio.sleep(10)
+
+        slow.send_ping = _slow_ping
+        client.sessions = {"slow_server": slow}
+
+        result = await client.health_check(timeout=0.1)
+        assert result == {"slow_server": False}
+
+    async def test_broken_resource_error_returns_false(self):
+        client = _make_client()
+        broken = MagicMock()
+        broken.send_ping = AsyncMock(side_effect=BrokenResourceError())
+        client.sessions = {"broken": broken}
+
+        result = await client.health_check()
+        assert result == {"broken": False}
+
+    async def test_httpx_transport_error_returns_false(self):
+        client = _make_client()
+        http_dead = MagicMock()
+        http_dead.send_ping = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        client.sessions = {"http_dead": http_dead}
+
+        result = await client.health_check()
+        assert result == {"http_dead": False}
+
+    async def test_uses_instance_timeout_by_default(self):
+        client = _make_client(health_check_timeout=1.0)
+        fast = MagicMock()
+        fast.send_ping = AsyncMock(return_value=None)
+        client.sessions = {"fast": fast}
+
+        result = await client.health_check()
+        assert result == {"fast": True}
+
+    async def test_timeout_arg_overrides_instance_default(self):
+        client = _make_client(health_check_timeout=60.0)
+        slow = MagicMock()
+
+        async def _slow_ping() -> None:
+            await asyncio.sleep(10)
+
+        slow.send_ping = _slow_ping
+        client.sessions = {"slow": slow}
+
+        result = await client.health_check(timeout=0.1)
+        assert result == {"slow": False}
+
+
+class TestSessionsHealthy:
+    """Tests for LongLivedMultiServerMCPClient.sessions_healthy() — debounced API."""
+
+    async def test_healthy_returns_true(self):
+        client = _make_client()
+        s1 = MagicMock()
+        s1.send_ping = AsyncMock(return_value=None)
+        client.sessions = {"server_a": s1}
+
+        assert await client.sessions_healthy() is True
+
+    async def test_dead_session_returns_false(self):
+        client = _make_client()
+        dead = MagicMock()
+        dead.send_ping = AsyncMock(side_effect=ClosedResourceError())
+        client.sessions = {"dead": dead}
+
+        assert await client.sessions_healthy() is False
+
+    async def test_empty_sessions_returns_true(self):
+        client = _make_client()
+        client.sessions = {}
+        assert await client.sessions_healthy() is True
+
+    async def test_debounce_skips_ping_within_interval(self):
+        client = _make_client(health_check_interval=30.0)
+        s1 = MagicMock()
+        s1.send_ping = AsyncMock(return_value=None)
+        client.sessions = {"server_a": s1}
+
+        assert await client.sessions_healthy() is True
+        assert s1.send_ping.call_count == 1
+
+        # Second call — within 30s interval, should skip ping
+        assert await client.sessions_healthy() is True
+        assert s1.send_ping.call_count == 1
+
+    async def test_debounce_expired_pings_again(self):
+        client = _make_client(health_check_interval=30.0)
+        s1 = MagicMock()
+        s1.send_ping = AsyncMock(return_value=None)
+        client.sessions = {"server_a": s1}
+
+        assert await client.sessions_healthy() is True
+        assert s1.send_ping.call_count == 1
+
+        # Force debounce to expire
+        client._last_healthy_ping = 0.0
+
+        assert await client.sessions_healthy() is True
+        assert s1.send_ping.call_count == 2
+
+    async def test_no_interval_pings_every_call(self):
+        client = _make_client(health_check_interval=None)
+        s1 = MagicMock()
+        s1.send_ping = AsyncMock(return_value=None)
+        client.sessions = {"server_a": s1}
+
+        await client.sessions_healthy()
+        await client.sessions_healthy()
+        await client.sessions_healthy()
+        assert s1.send_ping.call_count == 3
+
+    async def test_unhealthy_does_not_update_last_ping(self):
+        client = _make_client(health_check_interval=30.0)
+        dead = MagicMock()
+        dead.send_ping = AsyncMock(side_effect=ClosedResourceError())
+        client.sessions = {"dead": dead}
+
+        assert await client.sessions_healthy() is False
+        assert client._last_healthy_ping == 0.0
+
+    async def test_healthy_updates_last_ping(self):
+        client = _make_client(health_check_interval=30.0)
+        s1 = MagicMock()
+        s1.send_ping = AsyncMock(return_value=None)
+        client.sessions = {"server_a": s1}
+
+        assert client._last_healthy_ping == 0.0
+        assert await client.sessions_healthy() is True
+        assert client._last_healthy_ping > 0.0
+
+
+class TestStartResetsLastHealthyPing:
+    """Verify that start() resets _last_healthy_ping after opening sessions."""
+
+    async def test_start_resets_last_healthy_ping(self, monkeypatch):
+        client = LongLivedMultiServerMCPClient(
+            {
+                "math": {
+                    "command": "python3",
+                    "args": ["unused"],
+                    "transport": "stdio",
+                }
+            }
+        )
+        assert client._last_healthy_ping == 0.0
+
+        fake_session = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_session_cm(server_name, *, auto_initialize=True):
+            yield fake_session
+
+        monkeypatch.setattr(client, "session", fake_session_cm)
+
+        await client.start()
+        assert client._last_healthy_ping > 0.0
+        await client.stop()


### PR DESCRIPTION
Health-check API added on top of PR langchain-ai/langchain-mcp-adapters#419. (addressing issue langchain-ai/langchain#40487)

Adding a health-check layer directly onto LongLivedMultiServerMCPClient introduced here. This is a self-contained addition — zero changes to MultiServerMCPClient or any existing method in this PR.

**Why persistent sessions need this**

LongLivedMultiServerMCPClient keeps sessions alive across requests — but sessions will go stale (server restarts, deployments, idle timeouts, network blips). Without health checking, the first user request after a session dies hits a ClosedResourceError at tool-call time — the worst possible moment.

This is the standard test-on-borrow pattern used by every production connection pool.(eg JDBC / HikariCP,Apache HttpClient,Redis / Lettuce).	

MCP's send_ping() exists in the protocol spec for exactly this purpose.

**Exact changes to LongLivedMultiServerMCPClient**:

**1. Constructor — 2 new optional kwargs + 3 new instance attrs**

```
def __init__(
    self,
    connections=None, *,
    callbacks=None, tool_interceptors=None, tool_name_prefix=False,
    health_check_interval: float | None = None,  # NEW — debounce window (seconds)
    health_check_timeout: float = 5.0,            # NEW — ping timeout (seconds)
) -> None:
    ...
    self._health_check_interval = health_check_interval
    self._health_check_timeout = health_check_timeout
    self._last_healthy_ping: float = 0.0

```

**2. start() — 1 line added**:

`self._last_healthy_ping = time.monotonic()  # fresh sessions are healthy`

Added after self.sessions = sessions. Prevents redundant ping immediately after connect.

**3. health_check(timeout=None) -> dict[str, bool] — new method**

Raw per-server ping using MCP's send_ping()
All servers pinged in parallel via asyncio.gather
Bounded by asyncio.timeout (defaults to health_check_timeout)
Catches all exceptions — detection, not propagation

**4. sessions_healthy() -> bool — new method**

High-level debounced check for request loops
Skips ping if last successful check was within health_check_interval
_last_healthy_ping only updated on success (failures force re-check)
health_check_interval=None (default) → pings every call (backward-compatible)

The debounce prevents a thundering herd: without it, 50 concurrent requests each independently ping all MCP servers. With health_check_interval=30.0, exactly 1 ping fires per 30s regardless of concurrency.

**Tests — 17 new tests in test_health_check.py**
```

- TestHealthCheck(8 tests around healthy, dead, empty, timeout, broken, httpx, instance timeout, arg override)
- TestSessionsHealthy(8 tests around healthy, dead, empty, debounce skip, debounce expire, no-interval, unhealthy no update, healthy updates)
- TestStartResetsLastHealthyPing(1 test that start resets ping)

```