### PR TITLE
Add emem geospatial MCP example

### DIFF
--- a/examples/clients/emem-geospatial/README.md
+++ b/examples/clients/emem-geospatial/README.md
@@ -1,0 +1,31 @@
+# emem Geospatial MCP Client Example
+
+A LangGraph ReAct agent that connects to [emem](https://github.com/Vortx-AI/emem), a remote MCP server for signed geospatial facts, over Streamable HTTP.
+
+## What it does
+
+1. Connects to the public emem MCP endpoint at `https://emem.dev/mcp`.
+2. Auto-discovers all emem tools (locate, recall, compare, verify, etc.).
+3. Creates a ReAct agent that answers a geospatial verification question.
+4. The agent locates coordinates, recalls elevation / land cover / vegetation / surface water, and summarises with signed receipt `fact_cid`s.
+
+No API key is needed for emem reads.
+
+## Install
+
+```bash
+pip install langchain-mcp-adapters langgraph langchain-openai
+```
+
+## Run
+
+```bash
+export OPENAI_API_KEY="sk-..."
+python emem_geospatial_agent.py
+```
+
+## Links
+
+- emem GitHub: https://github.com/Vortx-AI/emem
+- MCP endpoint: https://emem.dev/mcp
+- MCP Registry: `io.github.Vortx-AI/emem`

--- a/examples/clients/emem-geospatial/emem_geospatial_agent.py
+++ b/examples/clients/emem-geospatial/emem_geospatial_agent.py
@@ -1,0 +1,55 @@
+"""emem geospatial MCP client example.
+
+Connects to the live emem MCP server over Streamable HTTP, auto-discovers
+all tools, and runs a LangGraph ReAct agent that answers a geospatial
+verification question about coordinates 23.351921, 85.309145.
+
+Install:
+    pip install langchain-mcp-adapters langgraph langchain-openai
+
+Usage:
+    export OPENAI_API_KEY="sk-..."
+    python emem_geospatial_agent.py
+"""
+
+import asyncio
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+from langchain_openai import ChatOpenAI
+
+EMEM_MCP_URL = "https://emem.dev/mcp"
+
+QUESTION = (
+    "I have coordinates 23.351921, 85.309145. "
+    "Locate this place, recall its geospatial facts (elevation, "
+    "land cover, vegetation, surface water), and summarise what "
+    "you find. Cite the signed receipt fact_cids in your answer."
+)
+
+
+async def main():
+    llm = ChatOpenAI(model="gpt-4.1-mini")
+
+    async with MultiServerMCPClient(
+        {
+            "emem": {
+                "transport": "streamable_http",
+                "url": EMEM_MCP_URL,
+            }
+        }
+    ) as client:
+        tools = client.get_tools()
+        print(f"Loaded {len(tools)} emem tools via MCP\n")
+
+        agent = create_react_agent(llm, tools)
+
+        response = await agent.ainvoke({"messages": [("user", QUESTION)]})
+
+        for msg in response["messages"]:
+            if hasattr(msg, "content") and msg.content:
+                print(f"[{msg.type}] {msg.content}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/clients/emem-geospatial/emem_geospatial_agent.py
+++ b/examples/clients/emem-geospatial/emem_geospatial_agent.py
@@ -2,7 +2,7 @@
 
 Connects to the live emem MCP server over Streamable HTTP, auto-discovers
 all tools, and runs a LangGraph ReAct agent that answers a geospatial
-verification question about coordinates 23.351921, 85.309145.
+verification question about coordinates 60.3172, 24.9633.
 
 Install:
     pip install langchain-mcp-adapters langgraph langchain-openai
@@ -21,7 +21,7 @@ from langchain_openai import ChatOpenAI
 EMEM_MCP_URL = "https://emem.dev/mcp"
 
 QUESTION = (
-    "I have coordinates 23.351921, 85.309145. "
+    "I have coordinates 60.3172, 24.9633. "
     "Locate this place, recall its geospatial facts (elevation, "
     "land cover, vegetation, surface water), and summarise what "
     "you find. Cite the signed receipt fact_cids in your answer."


### PR DESCRIPTION
Adds a client example showing how to connect LangChain/LangGraph to emem, a remote MCP server for signed geospatial facts and place-based verification.

The example uses `MultiServerMCPClient` with Streamable HTTP transport to auto-discover all emem tools and run a ReAct agent that locates coordinates, recalls geospatial facts, and cites signed receipts.

No API key needed for emem reads. No changes to library code.

## Files added

- `examples/clients/emem-geospatial/emem_geospatial_agent.py`
- `examples/clients/emem-geospatial/README.md`

## Links

- emem GitHub: https://github.com/Vortx-AI/emem
- MCP endpoint: https://emem.dev/mcp
- MCP Registry: io.github.Vortx-AI/emem