### PR TITLE
feat: add TrustGateInterceptor for pre-call trust verification

### DIFF
--- a/examples/trust_gate_example.py
+++ b/examples/trust_gate_example.py
@@ -1,0 +1,45 @@
+"""Example: Trust-gated MCP tool calls with Dominion Observatory.
+
+This example shows how to use TrustGateInterceptor to check MCP server
+behavioral trust scores before allowing tool calls. Servers below the
+threshold are blocked automatically.
+
+Requirements:
+    pip install langchain-mcp-adapters httpx
+"""
+
+import asyncio
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.trust_gate import TrustGateInterceptor
+
+# Create a trust gate — blocks calls to servers scoring below 60
+trust_gate = TrustGateInterceptor(
+    min_trust_score=60,
+    # observatory_url can be changed to any trust oracle
+    # that returns {"trust_score": <0-100>}
+    observatory_url="https://dominion-observatory.sgdata.workers.dev",
+)
+
+
+async def main():
+    # Pass the interceptor when creating the client
+    async with MultiServerMCPClient(
+        {
+            "observatory": {
+                "url": "https://dominion-observatory.sgdata.workers.dev/mcp",
+                "transport": "streamable_http",
+            },
+        },
+        interceptors=[trust_gate],
+    ) as client:
+        tools = client.get_tools()
+        print(f"Available tools: {[t.name for t in tools]}")
+
+        # When the agent invokes a tool, the trust gate checks the server
+        # trust score first. If trusted, the call proceeds. If not, the
+        # agent receives an explanation of why the call was blocked.
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/langchain_mcp_adapters/trust_gate.py
+++ b/langchain_mcp_adapters/trust_gate.py
@@ -1,0 +1,130 @@
+"""Trust gate interceptor for pre-call MCP server trust verification.
+
+Checks behavioral trust scores from a configurable trust oracle before
+allowing tool calls. Servers below the configured threshold are blocked
+with a clear explanation.
+
+The default trust oracle is Dominion Observatory
+(https://dominion-observatory.sgdata.workers.dev), which monitors 14,820+
+MCP servers. You can substitute any endpoint that returns a JSON object
+with a ``trust_score`` field (0-100).
+
+Example::
+
+    from langchain_mcp_adapters.trust_gate import TrustGateInterceptor
+
+    interceptor = TrustGateInterceptor(min_trust_score=60)
+    client = MultiServerMCPClient(interceptors=[interceptor], ...)
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import ToolMessage
+
+from langchain_mcp_adapters.interceptors import MCPToolCallRequest
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain_mcp_adapters.interceptors import MCPToolCallResult
+
+
+@dataclass
+class TrustGateInterceptor:
+    """Intercepts MCP tool calls and checks server trust before execution.
+
+    Queries a trust oracle (default: Dominion Observatory) to retrieve
+    a behavioral trust score for the target MCP server. If the score is
+    below ``min_trust_score``, the call is blocked and a ``ToolMessage``
+    with an explanation is returned instead.
+
+    Trust scores are cached for ``cache_ttl_seconds`` to avoid excessive
+    API calls.
+
+    Attributes:
+        observatory_url: Base URL of the trust oracle API.
+        min_trust_score: Minimum trust score (0-100) required to proceed.
+        api_key: Optional API key for paid tiers (enables audit receipts).
+        cache_ttl_seconds: How long to cache trust scores (default 300s).
+    """
+
+    observatory_url: str = "https://dominion-observatory.sgdata.workers.dev"
+    min_trust_score: float = 60.0
+    api_key: str | None = None
+    cache_ttl_seconds: int = 300
+    _cache: dict[str, tuple[float, float]] = field(
+        default_factory=dict, repr=False
+    )
+
+    async def _get_trust_score(self, server_name: str) -> dict[str, Any]:
+        """Fetch trust score from the observatory, with caching."""
+        now = time.time()
+        cached = self._cache.get(server_name)
+        if cached and (now - cached[1]) < self.cache_ttl_seconds:
+            return {"trust_score": cached[0], "cached": True}
+
+        import httpx
+
+        url = f"{self.observatory_url}/benchmark/{server_name}"
+        headers: dict[str, str] = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(url, headers=headers)
+                if resp.status_code == 200:
+                    data = resp.json()
+                    score = data.get("trust_score")
+                    if score is not None:
+                        self._cache[server_name] = (float(score), now)
+                    return data
+                return {"trust_score": None, "error": f"HTTP {resp.status_code}"}
+        except Exception as e:
+            return {"trust_score": None, "error": str(e)}
+
+    async def __call__(
+        self,
+        request: MCPToolCallRequest,
+        handler: Callable[[MCPToolCallRequest], Awaitable[MCPToolCallResult]],
+    ) -> MCPToolCallResult:
+        """Check trust score before allowing tool execution.
+
+        Args:
+            request: The MCP tool call request.
+            handler: The next handler in the interceptor chain.
+
+        Returns:
+            Tool result if trusted, or a ToolMessage explaining the block.
+        """
+        server_name = request.server_name
+        trust_data = await self._get_trust_score(server_name)
+        score = trust_data.get("trust_score")
+
+        if score is not None and score >= self.min_trust_score:
+            return await handler(request)
+
+        # Server didn't meet trust threshold — block the call
+        if score is None:
+            reason = (
+                f"Could not verify trust for MCP server '{server_name}'. "
+                f"Trust oracle returned: {trust_data.get('error', 'unknown error')}. "
+                f"The tool call was blocked for safety."
+            )
+        else:
+            reason = (
+                f"MCP server '{server_name}' has a trust score of {score:.1f}, "
+                f"which is below the minimum threshold of {self.min_trust_score}. "
+                f"The tool call '{request.name}' was blocked. "
+                f"Check {self.observatory_url}/benchmark/{server_name} for details."
+            )
+
+        return ToolMessage(
+            content=reason,
+            tool_call_id=request.name,
+            status="error",
+        )

--- a/tests/test_trust_gate.py
+++ b/tests/test_trust_gate.py
@@ -1,0 +1,147 @@
+"""Tests for TrustGateInterceptor."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from langchain_mcp_adapters.interceptors import MCPToolCallRequest
+from langchain_mcp_adapters.trust_gate import TrustGateInterceptor
+
+
+@pytest.fixture
+def interceptor() -> TrustGateInterceptor:
+    return TrustGateInterceptor(min_trust_score=60.0, cache_ttl_seconds=0)
+
+
+@pytest.fixture
+def request() -> MCPToolCallRequest:
+    return MCPToolCallRequest(
+        name="check_trust",
+        args={"server_url": "https://example.com/mcp"},
+        server_name="example-server",
+    )
+
+
+@pytest.fixture
+def handler() -> AsyncMock:
+    mock = AsyncMock()
+    mock.return_value = ToolMessage(content="success", tool_call_id="check_trust")
+    return mock
+
+
+def _mock_response(score: float | None, status: int = 200):
+    """Create a mock httpx response."""
+    import httpx
+
+    if score is not None:
+        data = {"trust_score": score, "server": "example-server"}
+    else:
+        data = {"error": "not found"}
+
+    resp = httpx.Response(
+        status_code=status,
+        json=data,
+        request=httpx.Request("GET", "https://example.com"),
+    )
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_trusted_server_passes(interceptor, request, handler):
+    """Tool call proceeds when server trust score meets threshold."""
+    with patch("httpx.AsyncClient") as mock_client:
+        instance = AsyncMock()
+        instance.get.return_value = _mock_response(85.0)
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client.return_value = instance
+
+        result = await interceptor(request, handler)
+
+    handler.assert_called_once_with(request)
+    assert isinstance(result, ToolMessage)
+    assert result.content == "success"
+
+
+@pytest.mark.asyncio
+async def test_untrusted_server_blocked(interceptor, request, handler):
+    """Tool call is blocked when server trust score is below threshold."""
+    with patch("httpx.AsyncClient") as mock_client:
+        instance = AsyncMock()
+        instance.get.return_value = _mock_response(30.0)
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client.return_value = instance
+
+        result = await interceptor(request, handler)
+
+    handler.assert_not_called()
+    assert isinstance(result, ToolMessage)
+    assert "trust score of 30.0" in result.content
+    assert "blocked" in result.content
+
+
+@pytest.mark.asyncio
+async def test_unreachable_oracle_blocks(interceptor, request, handler):
+    """Tool call is blocked when trust oracle is unreachable."""
+    with patch("httpx.AsyncClient") as mock_client:
+        instance = AsyncMock()
+        instance.get.side_effect = Exception("Connection refused")
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client.return_value = instance
+
+        result = await interceptor(request, handler)
+
+    handler.assert_not_called()
+    assert isinstance(result, ToolMessage)
+    assert "Could not verify trust" in result.content
+
+
+@pytest.mark.asyncio
+async def test_cache_reuses_score(request, handler):
+    """Cached scores are reused within TTL."""
+    interceptor = TrustGateInterceptor(
+        min_trust_score=60.0, cache_ttl_seconds=300
+    )
+
+    with patch("httpx.AsyncClient") as mock_client:
+        instance = AsyncMock()
+        instance.get.return_value = _mock_response(85.0)
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client.return_value = instance
+
+        # First call — hits the API
+        await interceptor(request, handler)
+        # Second call — should use cache
+        await interceptor(request, handler)
+
+    # httpx.AsyncClient should only be instantiated once (first call)
+    assert mock_client.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_custom_observatory_url(request, handler):
+    """Custom observatory URL is used for trust checks."""
+    interceptor = TrustGateInterceptor(
+        observatory_url="https://custom-trust.example.com",
+        min_trust_score=50.0,
+        cache_ttl_seconds=0,
+    )
+
+    with patch("httpx.AsyncClient") as mock_client:
+        instance = AsyncMock()
+        instance.get.return_value = _mock_response(75.0)
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=False)
+        mock_client.return_value = instance
+
+        await interceptor(request, handler)
+
+    instance.get.assert_called_once()
+    call_url = instance.get.call_args[0][0]
+    assert call_url.startswith("https://custom-trust.example.com/")


### PR DESCRIPTION
## Summary

Adds a `TrustGateInterceptor` that checks MCP server behavioral trust scores before allowing tool calls. Implements the `ToolCallInterceptor` protocol.

- Queries a configurable trust oracle (default: [Dominion Observatory](https://dominion-observatory.sgdata.workers.dev), 14,820+ servers monitored)
- Blocks calls to servers below a configurable `min_trust_score` threshold
- Returns a clear `ToolMessage` explaining why a call was blocked
- Caches scores (configurable TTL) to minimize API calls
- Observatory URL is fully configurable — works with any endpoint returning `{trust_score: <0-100>}`

## Files

- `langchain_mcp_adapters/trust_gate.py` — `TrustGateInterceptor` implementation
- `tests/test_trust_gate.py` — unit tests with mocked HTTP calls
- `examples/trust_gate_example.py` — usage with `MultiServerMCPClient`

## Why

The interceptor infrastructure exists but ships zero security implementations. There is no built-in way to check if an MCP server is reliable before calling it. This fills that gap as an opt-in interceptor.

Resolves #518