### PR TITLE
Fix: Handle partial failures gracefully in MultiServerMCPClient.get_tools()

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -5,6 +5,7 @@ to multiple MCP servers and loading tools, prompts, and resources from them.
 """
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import TracebackType
@@ -29,6 +30,8 @@ from langchain_mcp_adapters.sessions import (
     create_session,
 )
 from langchain_mcp_adapters.tools import load_mcp_tools
+
+logger = logging.getLogger(__name__)
 
 ASYNC_CONTEXT_MANAGER_ERROR = (
     "As of langchain-mcp-adapters 0.1.0, MultiServerMCPClient cannot be used as a "
@@ -181,9 +184,9 @@ class MultiServerMCPClient:
             )
 
         all_tools: list[BaseTool] = []
-        load_mcp_tool_tasks = []
-        for name, connection in self.connections.items():
-            load_mcp_tool_task = asyncio.create_task(
+        server_names = list(self.connections.keys())
+        load_mcp_tool_tasks = [
+            asyncio.create_task(
                 load_mcp_tools(
                     None,
                     connection=connection,
@@ -193,10 +196,16 @@ class MultiServerMCPClient:
                     tool_name_prefix=self.tool_name_prefix,
                 )
             )
-            load_mcp_tool_tasks.append(load_mcp_tool_task)
-        tools_list = await asyncio.gather(*load_mcp_tool_tasks)
-        for tools in tools_list:
-            all_tools.extend(tools)
+            for name, connection in self.connections.items()
+        ]
+        results = await asyncio.gather(*load_mcp_tool_tasks, return_exceptions=True)
+        for name, result in zip(server_names, results):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Failed to load tools from server '%s': %s", name, result
+                )
+            else:
+                all_tools.extend(result)
         return all_tools
 
     async def get_prompt(

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -5,6 +5,7 @@ to multiple MCP servers and loading tools, prompts, and resources from them.
 """
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import TracebackType
@@ -29,6 +30,8 @@ from langchain_mcp_adapters.sessions import (
     create_session,
 )
 from langchain_mcp_adapters.tools import load_mcp_tools
+
+logger = logging.getLogger(__name__)
 
 ASYNC_CONTEXT_MANAGER_ERROR = (
     "As of langchain-mcp-adapters 0.1.0, MultiServerMCPClient cannot be used as a "
@@ -192,9 +195,9 @@ class MultiServerMCPClient:
             )
 
         all_tools: list[BaseTool] = []
-        load_mcp_tool_tasks = []
-        for name, connection in self.connections.items():
-            load_mcp_tool_task = asyncio.create_task(
+        server_names = list(self.connections.keys())
+        load_mcp_tool_tasks = [
+            asyncio.create_task(
                 load_mcp_tools(
                     None,
                     connection=connection,
@@ -205,10 +208,16 @@ class MultiServerMCPClient:
                     handle_tool_errors=self.handle_tool_errors,
                 )
             )
-            load_mcp_tool_tasks.append(load_mcp_tool_task)
-        tools_list = await asyncio.gather(*load_mcp_tool_tasks)
-        for tools in tools_list:
-            all_tools.extend(tools)
+            for name, connection in self.connections.items()
+        ]
+        results = await asyncio.gather(*load_mcp_tool_tasks, return_exceptions=True)
+        for name, result in zip(server_names, results):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Failed to load tools from server '%s': %s", name, result
+                )
+            else:
+                all_tools.extend(result)
         return all_tools
 
     async def get_prompt(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -351,3 +351,53 @@ async def test_get_resources_from_specific_server():
     assert len(weather_resources) == 1
     assert str(weather_resources[0].metadata["uri"]) == "weather://forecast"
     assert weather_resources[0].data == "Sunny with a chance of clouds"
+
+
+async def test_get_tools_partial_failure(caplog):
+    """Test that get_tools() returns tools from healthy servers even when one fails.
+
+    If one server fails to connect, tools from all other servers must still
+    be returned instead of propagating the error and returning nothing.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from langchain_core.tools import BaseTool
+
+    healthy_tool = MagicMock(spec=BaseTool)
+    healthy_tool.name = "healthy_tool"
+
+    async def fake_load_mcp_tools(session, *, connection, server_name, **kwargs):
+        if server_name == "broken":
+            raise FileNotFoundError("command 'npx' not found in PATH")
+        return [healthy_tool]
+
+    client = MultiServerMCPClient(
+        {
+            "broken": {
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+                "transport": "stdio",
+            },
+            "healthy": {
+                "url": "http://localhost:9999/mcp",
+                "transport": "streamable_http",
+            },
+        }
+    )
+
+    with (
+        patch(
+            "langchain_mcp_adapters.client.load_mcp_tools",
+            side_effect=fake_load_mcp_tools,
+        ),
+        caplog.at_level(logging.WARNING, logger="langchain_mcp_adapters.client"),
+    ):
+        tools = await client.get_tools()
+
+    # Should still get tools from the healthy server
+    assert len(tools) == 1
+    assert tools[0].name == "healthy_tool"
+
+    # Should have logged a warning about the broken server
+    assert "broken" in caplog.text
+    assert "Failed to load tools" in caplog.text


### PR DESCRIPTION
Fixes #492

**Description**
Currently, `MultiServerMCPClient.get_tools()` fails silently and returns no tools at all if any single server fails to connect (e.g. command not found for stdio transport). This happens because `asyncio.gather` throws on the first error and cancels other tasks.

This PR:
- Changes `asyncio.gather` to use `return_exceptions=True`
- Collects tools from all healthy servers that connected successfully
- Logs a warning for any servers that failed to connect
- Adds a unit test verifying this behavior with mocked endpoints

This ensures that one broken server configuration doesn't break the entire multi-server setup.