### PR TITLE
docs: Document stateful MCP session usage (Playwright)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,15 +138,62 @@ weather_response = await agent.ainvoke({"messages": "what is the weather in nyc?
 ```
 
 > [!note]
-> Example above will start a new MCP `ClientSession` for each tool invocation. If you would like to explicitly start a session for a given server, you can do:
->
-> ```python
-> from langchain_mcp_adapters.tools import load_mcp_tools
->
-> client = MultiServerMCPClient({...})
-> async with client.session("math") as session:
->     tools = await load_mcp_tools(session)
+> The example above starts a **new MCP session for every individual tool call** (stateless). This works well for
+> stateless servers like math or weather where each call is independent.
+
+## Stateful MCP Servers (e.g. Playwright browser)
+
+Some MCP servers are **stateful** — they maintain context between calls. The most common example is a
+browser automation server like [Playwright MCP](https://github.com/microsoft/playwright-mcp): after
+`browser_navigate` opens a page, follow-up calls (`browser_snapshot`, `browser_click`, etc.) must
+reach the **same browser session**, or all references (element handles, page state) are gone.
+
+> [!IMPORTANT]
+> Using `client.get_tools()` with a stateful server causes a **new MCP process to be spawned for each
+> tool call**. The browser closes between calls, so element refs like `e13` no longer exist and you
+> will see errors like:
 > ```
+> Error: Ref e13 not found in the current page snapshot. Try capturing new snapshot.
+> ```
+> To keep the server alive for the full agent run, use `client.session()` and pass the session
+> directly to `load_mcp_tools()`.
+
+### Correct pattern for stateful servers
+
+```python
+import asyncio
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.tools import load_mcp_tools
+from langchain.agents import create_agent
+
+client = MultiServerMCPClient(
+    {
+        "playwright": {
+            "command": "npx",
+            "args": ["@playwright/mcp@latest"],
+            "transport": "stdio",
+        }
+    }
+)
+
+async def run():
+    # Keep a single MCP session open for the entire agent run.
+    # All tools loaded from this session share the same browser process.
+    async with client.session("playwright") as session:
+        tools = await load_mcp_tools(session)
+        agent = create_agent("openai:gpt-4.1", tools)
+        result = await agent.ainvoke({"messages": "Go to example.com and tell me the page title."})
+        print(result)
+
+asyncio.run(run())
+```
+
+The key difference is where the agent invocation happens:
+
+| Approach | Session lifetime | Use when |
+|---|---|---|
+| `client.get_tools()` | New session **per tool call** | Server is stateless (math, weather, file reads) |
+| `client.session()` + `load_mcp_tools(session)` | Single session for **entire `async with` block** | Server is stateful (browser, database transactions) |
 
 ## Streamable HTTP
 

--- a/examples/stateful_playwright_example.py
+++ b/examples/stateful_playwright_example.py
@@ -1,0 +1,72 @@
+import asyncio
+import os
+
+from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.tools import load_mcp_tools
+
+async def run_stateful_playwright_agent():
+    """
+    Example demonstrating how to use a stateful MCP server (like Playwright)
+    with LangChain agents.
+
+    Stateful servers require a persistent session across multiple tool calls.
+    If you use `client.get_tools()`, a new session is created for every tool call,
+    which will cause stateful operations (like navigating to a page, then clicking)
+    to fail because the browser context is lost between calls.
+
+    Instead, use `client.session()` to keep the connection open for the entire
+    agent run.
+    """
+    
+    # 1. Configure the client
+    client = MultiServerMCPClient(
+        {
+            "playwright": {
+                "command": "npx",
+                "args": ["-y", "@playwright/mcp@latest", "--isolated"],
+                "transport": "stdio",
+            }
+        }
+    )
+
+    # Note: Make sure OPENAI_API_KEY is set in your environment
+    if not os.environ.get("OPENAI_API_KEY"):
+        print("Please set OPENAI_API_KEY environment variable.")
+        return
+
+    model = ChatOpenAI(model="gpt-4o")
+
+    # 2. Use a persistent session
+    async with client.session("playwright") as session:
+        print("Connected to Playwright MCP Server.")
+        
+        # 3. Load tools using the persistent session
+        tools = await load_mcp_tools(session)
+        print(f"Loaded {len(tools)} tools.")
+        
+        # 4. Create the agent
+        agent = create_agent(model, tools)
+        
+        prompt = (
+            "Navigate to https://example.com. "
+            "Then, capture a snapshot of the page and tell me what the main heading says."
+        )
+        
+        print(f"Running agent with prompt: {prompt}")
+        
+        # 5. Invoke the agent. The browser context will persist across the multiple 
+        # tool calls (browser_navigate, browser_snapshot, etc.) because the 
+        # 'async with client.session()' block is keeping the server connection alive.
+        response = await agent.ainvoke(
+            {"messages": [HumanMessage(content=prompt)]}
+        )
+        
+        print("\nAgent Response:")
+        print(response)
+
+if __name__ == "__main__":
+    asyncio.run(run_stateful_playwright_agent())

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -166,9 +166,21 @@ class MultiServerMCPClient:
             server_name: Optional name of the server to get tools from.
                 If `None`, all tools from all servers will be returned.
 
-        !!! note
+        !!! warning "Stateless: a new session is created per tool call"
+            Each tool returned by this method opens a **fresh MCP session** every time it is
+            invoked and closes it immediately after. This is fine for stateless servers (math,
+            file reads, REST APIs) but will break stateful servers such as Playwright, where
+            browser context must survive across multiple tool calls within a single agent run.
 
-            A new session will be created for each tool call
+            For stateful servers use `client.session()` together with `load_mcp_tools(session)`
+            so all tools share one persistent connection:
+
+            ```python
+            async with client.session("playwright") as session:
+                tools = await load_mcp_tools(session)
+                agent = create_agent(model, tools)
+                result = await agent.ainvoke(...)
+            ```
 
         Returns:
             A list of LangChain [tools](https://docs.langchain.com/oss/python/langchain/tools)


### PR DESCRIPTION
Resolves langchain-ai/langchain#33966

## Summary
This PR documents the crucial difference between `client.get_tools()` (stateless, creates a new MCP session per tool invocation) and `client.session()` (stateful, maintains connection across multiple tools).

This addresses the common pitfall where browser sessions terminate immediately after navigation when using Playwright MCP tools with agents, as reported in [langchain-ai/langchain#33966](https://github.com/langchain-ai/langchain/issues/33966). As noted by maintainers in that issue, this documentation belongs in the MCP adapters repository rather than the core langchain agent documentation.

## Changes
1. Added a prominent **Stateful MCP Servers** section to the README explaining the issue and the correct pattern.
2. Updated the docstring for `MultiServerMCPClient.get_tools()` to explicitly warn developers about the stateless per-call session behavior.
3. Added a comprehensive example script (`examples/stateful_playwright_example.py`) demonstrating a working Playwright agent.
