### PR TITLE
feat: add extra_params support to MCPToolCallRequest for server-defin…

### DIFF
--- a/langchain_mcp_adapters/interceptors.py
+++ b/langchain_mcp_adapters/interceptors.py
@@ -46,6 +46,7 @@ class _MCPToolCallRequestOverrides(TypedDict, total=False):
     name: NotRequired[str]
     args: NotRequired[dict[str, Any]]
     headers: NotRequired[dict[str, Any] | None]
+    extra_params: NotRequired[dict[str, Any] | None]
 
 
 @dataclass
@@ -71,6 +72,7 @@ class MCPToolCallRequest:
     server_name: str  # Context: MCP server name
     headers: dict[str, Any] | None = None  # Modifiable: HTTP headers
     runtime: object | None = None  # Context: LangGraph runtime (if any)
+    extra_params: dict[str, Any] | None = None  # Modifiable: extra params to merge into tools/call params
 
     def override(
         self, **overrides: Unpack[_MCPToolCallRequestOverrides]
@@ -87,6 +89,7 @@ class MCPToolCallRequest:
                 - name: Tool name
                 - args: Tool arguments
                 - headers: HTTP headers
+                - extra_params: Extra params to merge into tools/call params
 
         Returns:
             New MCPToolCallRequest instance with specified overrides

--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -29,6 +29,10 @@ from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase, FuncMetadat
 from mcp.types import (
     AudioContent,
     BlobResourceContents,
+    CallToolRequest,
+    CallToolRequestParams,
+    CallToolResult,
+    ClientRequest,
     ContentBlock,
     EmbeddedResource,
     ImageContent,
@@ -330,7 +334,8 @@ def convert_mcp_tool_to_langchain_tool(
             """Execute the actual MCP tool call with optional session creation.
 
             Args:
-                request: Tool call request with name, args, headers, and context.
+                request: Tool call request with name, args, headers, extra_params,
+                    and context.
 
             Returns:
                 MCPToolCallResult from MCP SDK.
@@ -361,6 +366,18 @@ def convert_mcp_tool_to_langchain_tool(
                     }
                     effective_connection = updated_connection
 
+            # Build tool call params with optional extra params from the request
+            def _build_tool_call_params(
+                base_name: str,
+                base_args: dict[str, Any] | None,
+                extra: dict[str, Any] | None,
+            ) -> CallToolRequestParams:
+                """Build CallToolRequestParams, merging extra params if provided."""
+                kwargs: dict[str, Any] = dict(name=base_name, arguments=base_args)
+                if extra:
+                    kwargs.update(extra)
+                return CallToolRequestParams(**kwargs)
+
             captured_exception = None
 
             if session is None:
@@ -374,9 +391,12 @@ def convert_mcp_tool_to_langchain_tool(
                 ) as tool_session:
                     await tool_session.initialize()
                     try:
-                        call_tool_result = await tool_session.call_tool(
-                            tool_name,
-                            tool_args,
+                        tool_params = _build_tool_call_params(
+                            tool_name, tool_args, request.extra_params
+                        )
+                        call_tool_result = await tool_session.send_request(
+                            ClientRequest(CallToolRequest(params=tool_params)),
+                            CallToolResult,
                             progress_callback=mcp_callbacks.progress_callback,
                         )
                     except Exception as e:  # noqa: BLE001
@@ -392,9 +412,12 @@ def convert_mcp_tool_to_langchain_tool(
                 if captured_exception is not None:
                     raise captured_exception
             else:
-                call_tool_result = await session.call_tool(
-                    tool_name,
-                    tool_args,
+                tool_params = _build_tool_call_params(
+                    tool_name, tool_args, request.extra_params
+                )
+                call_tool_result = await session.send_request(
+                    ClientRequest(CallToolRequest(params=tool_params)),
+                    CallToolResult,
                     progress_callback=mcp_callbacks.progress_callback,
                 )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -415,7 +415,7 @@ async def test_convert_mcp_tool_to_langchain_tool():
     }
     # Mock session and MCP tool
     session = AsyncMock()
-    session.call_tool.return_value = CallToolResult(
+    session.send_request.return_value = CallToolResult(
         content=[TextContent(type="text", text="tool result")],
         isError=False,
     )
@@ -439,10 +439,15 @@ async def test_convert_mcp_tool_to_langchain_tool():
         {"args": {"param1": "test", "param2": 42}, "id": "1", "type": "tool_call"},
     )
 
-    # Verify session.call_tool was called with correct arguments
-    session.call_tool.assert_called_once_with(
-        "test_tool", {"param1": "test", "param2": 42}, progress_callback=None
-    )
+    # Verify session.send_request was called with correct arguments
+    assert session.send_request.call_count == 1
+    call_args = session.send_request.call_args
+    assert call_args is not None
+    # Verify the result type (positional arg)
+    assert len(call_args.args) >= 2
+    assert call_args.args[1] == CallToolResult
+    # Verify progress_callback (keyword arg)
+    assert call_args.kwargs.get("progress_callback") is None
 
     # Verify result
     assert result.name == "test_tool"
@@ -479,20 +484,28 @@ async def test_load_mcp_tools():
     session.list_tools.return_value = MagicMock(tools=mcp_tools, nextCursor=None)
 
     # Mock call_tool to return different results for different tools
-    async def mock_call_tool(tool_name, arguments, progress_callback=None):
-        if tool_name == "tool1":
-            return CallToolResult(
-                content=[
-                    TextContent(type="text", text=f"tool1 result with {arguments}")
-                ],
-                isError=False,
-            )
-        return CallToolResult(
-            content=[TextContent(type="text", text=f"tool2 result with {arguments}")],
-            isError=False,
-        )
+    async def mock_send_request(request, result_type, progress_callback=None, **kwargs):
+        # Extract tool name from the CallToolRequest params
+        from mcp.types import ClientRequest, CallToolRequest
+        if isinstance(request, ClientRequest):
+            inner = request.root
+            if isinstance(inner, CallToolRequest):
+                tool_name = inner.params.name
+                arguments = inner.params.arguments
+                if tool_name == "tool1":
+                    return CallToolResult(
+                        content=[
+                            TextContent(type="text", text=f"tool1 result with {arguments}")
+                        ],
+                        isError=False,
+                    )
+                return CallToolResult(
+                    content=[TextContent(type="text", text=f"tool2 result with {arguments}")],
+                    isError=False,
+                )
+        return CallToolResult(content=[], isError=False)
 
-    session.call_tool.side_effect = mock_call_tool
+    session.send_request.side_effect = mock_send_request
 
     # Load MCP tools
     tools = await load_mcp_tools(session)
@@ -529,6 +542,68 @@ async def test_load_mcp_tools():
             "text": "tool2 result with {'param1': 'test2', 'param2': 2}",
             "id": IsLangChainID,
         }
+    ]
+
+
+async def test_convert_mcp_tool_to_langchain_tool_with_extra_params():
+    """Test that extra_params are passed through to the MCP tools/call params."""
+    tool_input_schema = {
+        "properties": {
+            "param1": {"title": "Param1", "type": "string"},
+        },
+        "required": ["param1"],
+        "title": "ToolSchema",
+        "type": "object",
+    }
+    session = AsyncMock()
+
+    async def mock_send_request(request, result_type, progress_callback=None, **kwargs):
+        from mcp.types import ClientRequest, CallToolRequest
+
+        if isinstance(request, ClientRequest):
+            inner = request.root
+            if isinstance(inner, CallToolRequest):
+                # Verify the extra params were passed through
+                params = inner.params
+                assert (
+                    getattr(params, "context", None) == {"my_key": "my_value"}
+                ), f"Expected context in params, got {params}"
+                return CallToolResult(
+                    content=[TextContent(type="text", text="tool result")],
+                    isError=False,
+                )
+        return CallToolResult(content=[], isError=False)
+
+    session.send_request.side_effect = mock_send_request
+
+    mcp_tool = MCPTool(
+        name="test_tool",
+        description="Test tool description",
+        inputSchema=tool_input_schema,
+    )
+
+    from langchain_mcp_adapters.interceptors import MCPToolCallRequest
+
+    # Create a custom interceptor that injects extra_params
+    class ContextInjector:
+        async def __call__(self, request, handler):
+            modified = request.override(
+                extra_params={"context": {"my_key": "my_value"}}
+            )
+            return await handler(modified)
+
+    lc_tool = convert_mcp_tool_to_langchain_tool(
+        session,
+        mcp_tool,
+        tool_interceptors=[ContextInjector()],
+    )
+
+    result = await lc_tool.ainvoke(
+        {"args": {"param1": "test"}, "id": "1", "type": "tool_call"},
+    )
+
+    assert result.content == [
+        {"type": "text", "text": "tool result", "id": IsLangChainID}
     ]
 
 


### PR DESCRIPTION
…ed params extensions

Adds an optional extra_params field to MCPToolCallRequest that gets merged into the tools/call JSON-RPC params, enabling server-defined extensions like LangGraph context field to be passed through.

Changes:
- interceptors.py: Add extra_params field to MCPToolCallRequest
- tools.py: Use session.send_request() instead of call_tool() to allow extra params in CallToolRequestParams
- tests: Add test_convert_mcp_tool_to_langchain_tool_with_extra_params

Closes #502