### PR TITLE
docs: add x402 paid-server example (AgentScrape)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,36 @@ agent = create_agent("openai:gpt-4.1", tools)
 math_response = await agent.ainvoke({"messages": "what's (3 + 5) x 12?"})
 ```
 
+
+
+### Real-world example: AgentScrape (x402 paid server)
+
+For a working remote MCP server you can hit without running anything locally,
+[AgentScrape](https://agent-scrape.healingsunhaven.workers.dev) is a live
+Streamable HTTP MCP service using the [x402](https://www.x402.org) protocol
+for pay-per-call billing in USDC on Base mainnet. It exposes six web-scraping
+tools and has a 10-call free tier per wallet, so the example works zero-config.
+
+```python
+import asyncio
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+async def main():
+    client = MultiServerMCPClient({
+        "agentscrape": {
+            "url": "https://agent-scrape.healingsunhaven.workers.dev/mcp",
+            "transport": "streamable_http",
+        }
+    })
+    tools = await client.get_tools()
+    print(f"Loaded {len(tools)} AgentScrape tools")
+
+asyncio.run(main())
+```
+
+A complete LangGraph-integrated example with payment headers and an agent
+runtime is at [`examples/agentscrape_x402_example.py`](examples/agentscrape_x402_example.py).
+
 ## Passing runtime headers
 
 When connecting to MCP servers, you can include custom headers (e.g., for authentication or tracing) using the `headers` field in the connection configuration. This is supported for the following transports:

--- a/examples/agentscrape_x402_example.py
+++ b/examples/agentscrape_x402_example.py
@@ -1,0 +1,85 @@
+"""AgentScrape x402 MCP Example.
+
+Connect LangChain to AgentScrape, a pay-per-call web-scraping MCP server that
+uses the x402 payment protocol on Base USDC. Agents pay autonomously per call,
+no signup or API keys required.
+
+AgentScrape exposes six tools as a remote MCP server via Streamable HTTP:
+    - scrape_webpage          ($0.003) - markdown/html/text/json scrape
+    - extract_structured_data ($0.005) - AI extraction via Groq + Llama 4 Scout
+    - screenshot_webpage      ($0.003) - PNG screenshot with viewport control
+    - extract_metadata        ($0.002) - title, OG, Twitter, JSON-LD
+    - create_browser_session  ($0.001) - stateful browser session
+    - run_workflow            ($0.008) - multi-step atomic workflow up to 20 steps
+
+Free tier: 10 calls per wallet in the first 30 days. Beyond that, payment in
+USDC on Base mainnet (eip155:8453). The first 402 Payment Required response
+carries the canonical x402 payment requirements header; this example shows the
+unpaid (free-tier) usage. For paid usage, supply the X-PAYMENT-RESPONSE header
+in the headers kwarg below.
+
+Service URLs:
+    - Worker:    https://agent-scrape.healingsunhaven.workers.dev
+    - MCP:       https://agent-scrape.healingsunhaven.workers.dev/mcp
+    - x402:      https://agent-scrape.healingsunhaven.workers.dev/.well-known/x402.json
+    - A2A card:  https://agent-scrape.healingsunhaven.workers.dev/.well-known/agent.json
+    - GitHub:    https://github.com/hshintelligence/agent-scrape
+
+Run:
+    uv run python examples/agentscrape_x402_example.py
+"""
+
+import asyncio
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+
+async def main() -> None:
+    # Connect to AgentScrape's remote MCP endpoint over Streamable HTTP.
+    # AgentScrape automatically negotiates Streamable HTTP and falls back to
+    # SSE for legacy clients.
+    client = MultiServerMCPClient(
+        {
+            "agentscrape": {
+                "url": "https://agent-scrape.healingsunhaven.workers.dev/mcp",
+                "transport": "streamable_http",
+                # Uncomment and supply a real x402 payment receipt for paid calls:
+                # "headers": {
+                #     "X-PAYMENT-RESPONSE": "<base64-encoded x402 payment receipt>",
+                # },
+            }
+        }
+    )
+
+    # Pull all of AgentScrape's tools as LangChain tools.
+    tools = await client.get_tools()
+    print(f"Loaded {len(tools)} tools from AgentScrape:")
+    for t in tools:
+        print(f"  - {t.name}")
+
+    # Build a LangGraph agent that uses these tools.
+    model = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    agent = create_react_agent(model, tools)
+
+    # Ask the agent to scrape a page.
+    result = await agent.ainvoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "Scrape https://www.x402.org and tell me the "
+                        "headline plus a 2-sentence summary."
+                    ),
+                }
+            ]
+        }
+    )
+
+    print("\nAgent response:\n", result["messages"][-1].content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What this PR adds

1. `examples/agentscrape_x402_example.py` — a working LangGraph agent that connects to [AgentScrape](https://agent-scrape.healingsunhaven.workers.dev), a live x402-protocol pay-per-call web-scraping MCP server.
2. A short "Real-world example: AgentScrape" section in the README under `## Streamable HTTP`, giving readers a remote MCP server they can hit without running anything locally.

## Why

The current Streamable HTTP section's only example points at `http://localhost:3000/mcp` which requires running the example server locally. There's no demonstration of connecting to a real, internet-facing Streamable HTTP MCP service. This PR fills that gap and also showcases integration with the emerging [x402 payment protocol](https://docs.cdp.coinbase.com/x402/overview) — the Coinbase-introduced agent-native payment standard now supported by AgentKit.

## What AgentScrape is

- Live remote MCP server: `https://agent-scrape.healingsunhaven.workers.dev/mcp` (Streamable HTTP)
- Six tools: scrape, extract (Groq+Llama 4), screenshot, metadata, session, workflow
- Open source MIT: https://github.com/hshintelligence/agent-scrape
- Free tier: 10 calls per wallet in first 30 days (example works zero-config)
- Paid mode: USDC on Base mainnet via x402 v2

## Why this is safe

- Adds one new file under `examples/` — no behavior changes to the adapter
- README change is purely additive (new subsection)
- Uses only public APIs already exported by `langchain-mcp-adapters`
- AgentScrape is vetted on [punkpeye/awesome-mcp-servers (#6837 merged)](https://github.com/punkpeye/awesome-mcp-servers/pull/6837), Glama (License A / Quality A), Smithery (82/100), mcp.so

Mirrors the equivalent PR I just opened on the JS adapter ([langchainjs#10959](https://github.com/langchain-ai/langchainjs/pull/10959)). Happy to address feedback or scope back as needed.