### PR TITLE
fix(client): add early validation for connection config in MultiServe…

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -41,6 +41,70 @@ ASYNC_CONTEXT_MANAGER_ERROR = (
     "       tools = await load_mcp_tools(session)"
 )
 
+# ============================================================
+# Connection config validation
+# ============================================================
+
+_VALID_TRANSPORTS = frozenset({"stdio", "sse", "streamable_http", "websocket"})
+
+_TRANSPORT_REQUIRED_KEYS: dict[str, frozenset[str]] = {
+    "stdio":           frozenset({"command", "args"}),
+    "sse":             frozenset({"url"}),
+    "streamable_http": frozenset({"url"}),
+    "websocket":       frozenset({"url"}),
+}
+
+def _validate_connections(connections: dict) -> None:
+    """Validate connections dict and raise a clear error if malformed.
+
+    Catches three common mistakes when copying config from
+    MCP-standard JSON descriptors (Claude Desktop, ModelScope, etc.):
+    1. ``"mcpServers"`` wrapper left in place
+    2. ``"type"`` used instead of ``"transport"``
+    3. Missing ``"transport"`` or transport-required keys (e.g. ``"url"``)
+    """
+    for name, config in connections.items():
+        if not isinstance(config, dict):
+            raise TypeError(
+                f"Connection '{name}' must be a dict, "
+                f"got {type(config).__name__}."
+            )
+
+        if "transport" not in config:
+            if "type" in config:
+                raise ValueError(
+                    f"Connection '{name}' uses 'type' instead of "
+                    f"'transport'. If you copied this config from an "
+                    f"MCP-standard JSON descriptor (e.g. Claude Desktop "
+                    f"or ModelScope), note that the top-level 'mcpServers' "
+                    f"key must be removed and 'type' renamed to 'transport'."
+                )
+            if any(isinstance(v, dict) for v in config.values()):
+                raise ValueError(
+                    f"Connection '{name}' appears to have an extra "
+                    f"layer of nesting. Unwrap the top-level "
+                    f"'mcpServers' key and pass the inner dict directly."
+                )
+            raise ValueError(
+                f"Connection '{name}' is missing the required "
+                f"'transport' key. "
+                f"Expected one of: {sorted(_VALID_TRANSPORTS)}"
+            )
+
+        transport = config["transport"]
+        if transport not in _VALID_TRANSPORTS:
+            raise ValueError(
+                f"Connection '{name}': invalid transport "
+                f"'{transport}'. "
+                f"Expected one of: {sorted(_VALID_TRANSPORTS)}"
+            )
+
+        missing = _TRANSPORT_REQUIRED_KEYS[transport] - config.keys()
+        if missing:
+            raise ValueError(
+                f"Connection '{name}' (transport='{transport}') "
+                f"is missing required key(s): {sorted(missing)}"
+            )
 
 class MultiServerMCPClient:
     """Client for connecting to multiple MCP servers.
@@ -104,6 +168,9 @@ class MultiServerMCPClient:
                 tools = await load_mcp_tools(session)
             ```
         """
+        if connections is not None:
+            _validate_connections(connections)
+
         self.connections: dict[str, Connection] = (
             connections if connections is not None else {}
         )


### PR DESCRIPTION
## Problem

When a connection config is malformed — e.g. copied directly from an
MCP-standard JSON descriptor (with `"mcpServers"` wrapper and `"type"`
instead of `"transport"`) — `MultiServerMCPClient` does not validate
it at construction time. The bad config is stored silently and only
fails much later, when `get_tools()` or `ainvoke()` is called. At that
point the error surfaces as:

```
openai.OpenAIError: The api_key client option must be set either by
passing api_key to the client or by setting the OPENAI_API_KEY
environment variable
```

This is **misleading** — the real problem is the config format, not
the API key. It wastes significant debugging time, especially for
newcomers who follow MCP platform documentation.

### Minimal reproduction

```python
from langchain_mcp_adapters.client import MultiServerMCPClient

# Copied from a ModelScope MCP page — common mistake
client = MultiServerMCPClient({
    "mcpServers": {                        # ← should not be here
        "fetch": {
            "type": "streamable_http",     # ← should be "transport"
            "url": "https://..."
        }
    }
})

tools = await client.get_tools()
# → OpenAIError about api_key (misleading!)
```

### Root cause

`__init__` stores `connections` as-is without any format check.
The downstream `get_tools()` tries to use the malformed dict as a
`Connection` TypedDict, fails, and the error propagates through an
unrelated code path that touches the OpenAI client.

### Solution

Add a module-level `_validate_connections()` that runs in `__init__`
*before* storing the config. It catches three categories of mistakes:

| Mistake | Error message |
|---|---|
| `"mcpServers"` wrapper left in place | `... has an extra layer of nesting. Unwrap ...` |
| `"type"` used instead of `"transport"` | `... uses 'type' instead of 'transport' ...` |
| Missing `"transport"` or required keys | `... missing required key(s): ['url']` |

The check is a **pure addition** — valid configs are unaffected.

### Files changed

- `langchain_mcp_adapters/client.py` — added `_validate_connections()`
  and its constants; added one call in `__init__`.


### Checklist

- [x] Existing tests pass (`pytest`)
- [x] No new dependencies introduced
Closes #526