### PR TITLE
docs: add 'Connecting to public MCP servers' section with OpenAccountants example

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,3 +327,36 @@ In your [`langgraph.json`](https://langchain-ai.github.io/langgraph/cloud/refere
   }
 }
 ```
+
+## Connecting to public MCP servers
+
+You can connect to any public MCP server using `MultiServerMCPClient` — no extra setup needed beyond the URL.
+
+### Example: OpenAccountants
+
+[OpenAccountants](https://www.openaccountants.com) is an open library of 800+ accountant-verified tax skills across 190+ jurisdictions, served over a public MCP endpoint. Useful when your LangChain agent needs to compute VAT, classify bookkeeping transactions, or walk a user through a tax return — every skill is signed off by a named licensed accountant.
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain.agents import create_agent
+
+client = MultiServerMCPClient(
+    {
+        "openaccountants": {
+            "transport": "streamable_http",
+            "url": "https://www.openaccountants.com/api/mcp",
+        }
+    }
+)
+tools = await client.get_tools()
+agent = create_agent("anthropic:claude-sonnet-4-5", tools)
+
+response = await agent.ainvoke({
+    "messages": "I'm a Maltese freelancer earning EUR 45,000 from foreign clients. What VAT obligations do I have?"
+})
+print(response["messages"][-1].content)
+```
+
+Full working examples (bookkeeping classification, cross-border tax comparison, Jupyter notebook): [openaccountants/langchain-example](https://github.com/openaccountants/langchain-example).
+
+> If you maintain a public MCP server that's a useful real-world example, feel free to open a PR adding it to this section.


### PR DESCRIPTION
## What this PR does

Adds a small new section near the end of `README.md` titled **"Connecting to public MCP servers"**, showing how to use `MultiServerMCPClient` against a real public, no-auth, production MCP server. Seeds the section with [OpenAccountants](https://www.openaccountants.com) as a worked example.

## Why

A LangChain developer browsing this README today sees stdio + local-HTTP server examples but no concrete real-world MCP server they can point at to play with the adapter end-to-end. Surfacing a public no-auth example:

- Shortens \"hello world\" — anyone can copy-paste the snippet and have a working agent in 30 seconds, no MCP-server setup
- Demonstrates streamable-HTTP transport with a remote URL (vs the existing local-process examples)
- Gives MCP-curious folks a reason to keep reading

## What OpenAccountants is

Open library of 800+ accountant-verified tax skills across 190+ jurisdictions, each signed off by a named licensed accountant. Public MCP server at `https://www.openaccountants.com/api/mcp` (no auth, rate-limited to 60 req/min/IP). MIT-licensed example repo: https://github.com/openaccountants/langchain-example

## Code added is copy-paste runnable

The snippet uses the standard \`MultiServerMCPClient\` + \`create_agent\` pattern already shown elsewhere in the README, so no new conventions or imports.

## Open invitation

I framed the section as an open list — the closing note invites other public MCP server maintainers to PR additional entries. Happy to defer to maintainer judgment on whether this should stay a one-entry section, become a curated list, or move to a separate \`docs/community-servers.md\` page.

## Diff

One section appended to README.md. Nothing else changed. No code paths touched.