### PR TITLE
Preserve reserved MCP tool argument names

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -172,6 +172,20 @@ class MCPToolArtifact(TypedDict):
     structured_content: dict[str, Any]
 
 
+class MCPStructuredTool(StructuredTool):
+    """StructuredTool variant that preserves MCP args named like LangChain internals."""
+
+    def _run(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        msg = "StructuredTool does not support sync invocation."
+        raise NotImplementedError(msg)
+
+    async def _arun(self, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+        if self.coroutine:
+            return await self.coroutine(*args, **kwargs)
+
+        return await super()._arun(*args, **kwargs)
+
+
 def _convert_mcp_content_to_lc_block(  # noqa: PLR0911
     content: ContentBlock,
 ) -> ToolMessageContentBlock:
@@ -525,7 +539,7 @@ def convert_mcp_tool_to_langchain_tool(
     # current content-block recognition and is locked by
     # `test_mcp_tool_error_preserves_non_text_content`.
     error_handler = _handle_mcp_tool_error if handle_tool_errors else False
-    return StructuredTool(
+    return MCPStructuredTool(
         name=lc_tool_name,
         description=tool.description or "",
         args_schema=tool.inputSchema,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -452,6 +452,48 @@ async def test_convert_mcp_tool_to_langchain_tool():
     ]
 
 
+@pytest.mark.parametrize("argument_name", ["callbacks", "config", "run_manager"])
+async def test_convert_mcp_tool_preserves_langchain_reserved_argument_names(
+    argument_name: str,
+):
+    tool_input_schema = {
+        "properties": {
+            argument_name: {"title": argument_name.title(), "type": "string"},
+            "query": {"title": "Query", "type": "string"},
+        },
+        "required": [argument_name, "query"],
+        "title": "ToolSchema",
+        "type": "object",
+    }
+    session = AsyncMock()
+    session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text="tool result")],
+        isError=False,
+    )
+
+    mcp_tool = MCPTool(
+        name="config_tool",
+        description="Test tool description",
+        inputSchema=tool_input_schema,
+    )
+
+    lc_tool = convert_mcp_tool_to_langchain_tool(session, mcp_tool)
+
+    await lc_tool.ainvoke(
+        {
+            "args": {argument_name: "user_value", "query": "hello"},
+            "id": "1",
+            "type": "tool_call",
+        },
+    )
+
+    session.call_tool.assert_called_once_with(
+        "config_tool",
+        {argument_name: "user_value", "query": "hello"},
+        progress_callback=None,
+    )
+
+
 async def test_load_mcp_tools():
     tool_input_schema = {
         "properties": {


### PR DESCRIPTION
## Summary
- Fixes MCP tool arguments named `config`, `callbacks`, or `run_manager` being dropped or overwritten during LangChain tool invocation
- Uses an adapter-local `StructuredTool` subclass that avoids exposing LangChain reserved parameter names on `_arun`
- Adds regression coverage for all three reserved argument names

Fixes langchain-ai/langchain#40476

## Tests
- `uv run --group test pytest tests/test_tools.py::test_convert_mcp_tool_to_langchain_tool tests/test_tools.py::test_convert_mcp_tool_preserves_langchain_reserved_argument_names -q`
- `uv run --group test ruff check langchain_mcp_adapters/tools.py tests/test_tools.py`