### PR TITLE
feat: add TWZRD Agent Intel remote streamable-HTTP MCP example

### DIFF
--- a/examples/servers/twzrd-agent-intel/README.md
+++ b/examples/servers/twzrd-agent-intel/README.md
@@ -1,0 +1,140 @@
+# TWZRD Agent Intel — Remote Streamable-HTTP MCP Example
+
+This example demonstrates how to connect a LangGraph agent to [TWZRD Agent Intel](https://intel.twzrd.xyz), a production remote MCP server that trust-scores Solana wallets before making HTTP 402 micropayments.
+
+No local server required — TWZRD Agent Intel runs at `https://intel.twzrd.xyz/mcp` and exposes three tools:
+
+| Tool | Cost | Description |
+|------|------|-------------|
+| `score_agent` | Free | On-chain trust score (0–100) for a Solana wallet |
+| `preflight_check` | Free | Boolean readiness check — is this wallet safe to pay? |
+| `get_trust_receipt` | Paid (x402) | Signed `twzrd.receipt.v5` receipt via USDC micropayment |
+
+## Use case
+
+Before an agent sends a USDC micropayment to an unknown Solana wallet address, call `score_agent` or `preflight_check` to verify the recipient's on-chain reputation.
+
+## Installation
+
+```bash
+pip install langchain-mcp-adapters langgraph langchain-openai
+export OPENAI_API_KEY=<your_api_key>
+```
+
+## Usage
+
+### Quick check — trust-score a wallet before paying
+
+```python
+import asyncio
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+from langchain_openai import ChatOpenAI
+
+async def check_wallet_before_paying(wallet: str):
+    async with MultiServerMCPClient({
+        "twzrd": {
+            "url": "https://intel.twzrd.xyz/mcp",
+            "transport": "streamable_http",
+        }
+    }) as client:
+        tools = client.get_tools()
+        model = ChatOpenAI(model="gpt-4o-mini")
+        agent = create_react_agent(model, tools)
+
+        response = await agent.ainvoke({
+            "messages": f"Should I send a USDC payment to {wallet}? "
+                        "Use the preflight_check tool to verify it's safe."
+        })
+        return response["messages"][-1].content
+
+# Example
+wallet = "4LkEFjwNNg6XRSXqD6UFMB6neLEQPKFSVBRzXQo8kNgf"
+result = asyncio.run(check_wallet_before_paying(wallet))
+print(result)
+```
+
+### Direct tool invocation
+
+```python
+import asyncio
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+async def score_wallet(wallet: str):
+    async with MultiServerMCPClient({
+        "twzrd": {
+            "url": "https://intel.twzrd.xyz/mcp",
+            "transport": "streamable_http",
+        }
+    }) as client:
+        tools = client.get_tools()
+        score_tool = next(t for t in tools if t.name == "score_agent")
+        result = await score_tool.ainvoke({"wallet": wallet})
+        print(f"Trust score for {wallet}: {result}")
+
+asyncio.run(score_wallet("4LkEFjwNNg6XRSXqD6UFMB6neLEQPKFSVBRzXQo8kNgf"))
+```
+
+### LangGraph StateGraph with trust-gated payment
+
+```python
+import asyncio
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.graph import StateGraph, MessagesState, START
+from langgraph.prebuilt import ToolNode, tools_condition
+from langchain_openai import ChatOpenAI
+
+async def build_trust_gated_agent():
+    client = MultiServerMCPClient({
+        "twzrd": {
+            "url": "https://intel.twzrd.xyz/mcp",
+            "transport": "streamable_http",
+        }
+    })
+    tools = await client.get_tools()
+    model = ChatOpenAI(model="gpt-4o-mini").bind_tools(tools)
+
+    def call_model(state: MessagesState):
+        return {"messages": model.invoke(state["messages"])}
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("call_model", call_model)
+    builder.add_node("tools", ToolNode(tools))
+    builder.add_edge(START, "call_model")
+    builder.add_conditional_edges("call_model", tools_condition)
+    builder.add_edge("tools", "call_model")
+    return builder.compile(), client
+
+async def main():
+    graph, client = await build_trust_gated_agent()
+
+    wallet = "4LkEFjwNNg6XRSXqD6UFMB6neLEQPKFSVBRzXQo8kNgf"
+    response = await graph.ainvoke({
+        "messages": f"Run preflight_check on {wallet}. "
+                    "If it passes, tell me the trust score using score_agent."
+    })
+    print(response["messages"][-1].content)
+    await client.aclose()
+
+asyncio.run(main())
+```
+
+## MCP configuration
+
+To add TWZRD Agent Intel to any MCP-compatible client:
+
+```json
+{
+  "mcpServers": {
+    "twzrd-agent-intel": {
+      "url": "https://intel.twzrd.xyz/mcp"
+    }
+  }
+}
+```
+
+## Links
+
+- Website: https://intel.twzrd.xyz
+- MCP endpoint: https://intel.twzrd.xyz/mcp
+- OpenAPI: https://intel.twzrd.xyz/openapi.json

--- a/examples/servers/twzrd-agent-intel/client.py
+++ b/examples/servers/twzrd-agent-intel/client.py
@@ -1,0 +1,102 @@
+"""
+TWZRD Agent Intel — LangChain MCP Adapters Example Client
+
+Demonstrates connecting to a remote Streamable-HTTP MCP server (TWZRD Agent Intel)
+to trust-score Solana wallets before making x402 micropayments.
+
+Usage:
+    pip install langchain-mcp-adapters langgraph langchain-openai
+    export OPENAI_API_KEY=<your_key>
+    python client.py
+"""
+import asyncio
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.graph import StateGraph, MessagesState, START
+from langgraph.prebuilt import ToolNode, tools_condition, create_react_agent
+from langchain_openai import ChatOpenAI
+
+TWZRD_MCP_URL = "https://intel.twzrd.xyz/mcp"
+
+# --- Example 1: Direct tool call ---
+
+async def score_wallet(wallet: str) -> None:
+    """Directly invoke the score_agent tool on a Solana wallet."""
+    async with MultiServerMCPClient({
+        "twzrd": {"url": TWZRD_MCP_URL, "transport": "streamable_http"}
+    }) as client:
+        tools = client.get_tools()
+        score_tool = next(t for t in tools if t.name == "score_agent")
+        result = await score_tool.ainvoke({"wallet": wallet})
+        print(f"[score_agent] {wallet}: {result}")
+
+
+# --- Example 2: React agent with preflight check ---
+
+async def preflight_agent(wallet: str) -> str:
+    """Use a ReAct agent to decide whether a wallet is safe to pay."""
+    async with MultiServerMCPClient({
+        "twzrd": {"url": TWZRD_MCP_URL, "transport": "streamable_http"}
+    }) as client:
+        tools = client.get_tools()
+        model = ChatOpenAI(model="gpt-4o-mini")
+        agent = create_react_agent(model, tools)
+        response = await agent.ainvoke({
+            "messages": (
+                f"Run preflight_check on wallet {wallet}. "
+                "Report whether it is safe to send a USDC payment and why."
+            )
+        })
+        return response["messages"][-1].content
+
+
+# --- Example 3: LangGraph StateGraph with trust-gated payment logic ---
+
+async def build_payment_guard_graph():
+    """
+    Build a LangGraph agent that uses TWZRD trust tools to gate payments.
+    The agent calls score_agent and preflight_check before approving a transfer.
+    """
+    client = MultiServerMCPClient({
+        "twzrd": {"url": TWZRD_MCP_URL, "transport": "streamable_http"}
+    })
+    tools = await client.get_tools()
+    model = ChatOpenAI(model="gpt-4o-mini").bind_tools(tools)
+
+    def call_model(state: MessagesState):
+        return {"messages": model.invoke(state["messages"])}
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("call_model", call_model)
+    builder.add_node("tools", ToolNode(tools))
+    builder.add_edge(START, "call_model")
+    builder.add_conditional_edges("call_model", tools_condition)
+    builder.add_edge("tools", "call_model")
+    graph = builder.compile()
+    return graph, client
+
+
+async def main():
+    wallet = "4LkEFjwNNg6XRSXqD6UFMB6neLEQPKFSVBRzXQo8kNgf"
+
+    print("=== Example 1: Direct score_agent tool call ===")
+    await score_wallet(wallet)
+
+    print("\n=== Example 2: ReAct agent preflight check ===")
+    result = await preflight_agent(wallet)
+    print(result)
+
+    print("\n=== Example 3: LangGraph StateGraph trust-gated payment ===")
+    graph, client = await build_payment_guard_graph()
+    response = await graph.ainvoke({
+        "messages": (
+            f"I need to send 1 USDC to {wallet}. "
+            "First run preflight_check. If it passes, run score_agent and give me "
+            "a final recommendation on whether to proceed with the payment."
+        )
+    })
+    print(response["messages"][-1].content)
+    await client.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds a new example in `examples/servers/twzrd-agent-intel/` demonstrating how to connect a LangGraph agent to a **production remote Streamable-HTTP MCP server** — [TWZRD Agent Intel](https://intel.twzrd.xyz).

This complements the existing `streamable-http-stateless` example (which requires running a local server) with a real-world remote server use case.

### What's included

- `README.md` — overview, tool table, installation, three usage patterns
- `client.py` — three working examples:
  1. Direct `score_agent` tool invocation
  2. ReAct agent with `preflight_check`
  3. LangGraph `StateGraph` with trust-gated payment logic

### About TWZRD Agent Intel

TWZRD Agent Intel ([intel.twzrd.xyz/mcp](https://intel.twzrd.xyz/mcp)) is a Solana trust-scoring MCP server for x402 agent payments. Tools:

| Tool | Cost | Description |
|------|------|-------------|
| `score_agent` | Free | On-chain trust score (0–100) for a Solana wallet |
| `preflight_check` | Free | Boolean readiness check before sending a payment |
| `get_trust_receipt` | Paid (HTTP 402 / x402) | Signed receipt via USDC micropayment |

MCP config:
```json
{
  "mcpServers": {
    "twzrd-agent-intel": {
      "url": "https://intel.twzrd.xyz/mcp"
    }
  }
}
```

The server is live and the tools work today — the `score_agent` and `preflight_check` tools are free and require no API key.