### PR TITLE
fix: bump mcp minimum version to 1.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=1.0.0,<2.0.0",
-    "mcp>=1.9.2",
+    "mcp>=1.24.0",
     "typing-extensions>=4.14.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -519,7 +519,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", specifier = ">=1.0.0,<2.0.0" },
-    { name = "mcp", specifier = ">=1.9.2" },
+    { name = "mcp", specifier = ">=1.24.0" },
     { name = "typing-extensions", specifier = ">=4.14.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Bumps the `mcp` dependency constraint from `>=1.9.2` to `>=1.24.0` in `pyproject.toml` and `uv.lock`

## Problem

Upgrading to `langchain-mcp-adapters==0.3.0` without upgrading `mcp` causes an immediate `ImportError` on import because `mcp>=1.9.2` allowed pip to leave an older `mcp` version in place. The adapter uses two APIs introduced in `mcp==1.24.0`:

- `mcp.client.streamable_http.streamable_http_client` (renamed from `streamablehttp_client` in older versions)
- `mcp.client.session.ElicitationFnT`

Both are imported unconditionally at the top level, so any `mcp` version below `1.24.0` breaks the package on import.

## Test plan

- [x] Install with `mcp==1.23.3` → `ImportError` reproduced (confirms #550)
- [x] Install with `mcp==1.24.0` → clean import confirmed

Fixes #550
