### PR TITLE
fix: strip generated ids from MCP tool result content blocks

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -5,7 +5,7 @@ tools, handle tool execution, and manage tool conversion between the two formats
 """
 
 from collections.abc import Awaitable, Callable
-from typing import Annotated, Any, TypedDict, get_args
+from typing import Annotated, Any, TypedDict, cast, get_args
 
 from langchain_core.messages import ToolMessage
 from langchain_core.messages.content import (
@@ -65,6 +65,15 @@ else:
     ConvertedToolResult = list[ToolMessageContentBlock] | ToolMessage
 
 MAX_ITERATIONS = 1000
+
+
+def _strip_content_block_id(
+    block: ToolMessageContentBlock,
+) -> ToolMessageContentBlock:
+    """Remove LangChain's generated block id before returning MCP tool output."""
+    block_without_id = dict(block)
+    block_without_id.pop("id", None)
+    return cast("ToolMessageContentBlock", block_without_id)
 
 
 def _summarize_tool_error(tool_content: list[ToolMessageContentBlock]) -> str:
@@ -154,7 +163,7 @@ def _handle_mcp_tool_error(
     if isinstance(error, _MCPToolExecutionError):
         if error.tool_content:
             return error.tool_content
-        return [create_text_block(text=str(error))]
+        return [_strip_content_block_id(create_text_block(text=str(error)))]
     raise error
 
 
@@ -266,7 +275,7 @@ def _convert_call_tool_result(
 
     # Convert all MCP content blocks to LangChain content blocks
     tool_content: list[ToolMessageContentBlock] = [
-        _convert_mcp_content_to_lc_block(content)
+        _strip_content_block_id(_convert_mcp_content_to_lc_block(content))
         for content in call_tool_result.content
     ]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,6 @@ from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.sessions import _create_stdio_session
 from langchain_mcp_adapters.tools import load_mcp_tools
-from tests.utils import IsLangChainID
 
 
 @pytest.fixture
@@ -179,24 +178,22 @@ async def test_multi_server_mcp_client(
     # Test that we can call a math tool
     add_tool = next(tool for tool in all_tools if tool.name == "add")
     result = await add_tool.ainvoke({"a": 2, "b": 3})
-    assert result == [{"type": "text", "text": "5", "id": IsLangChainID}]
+    assert result == [{"type": "text", "text": "5"}]
 
     # Test that we can call a weather tool
     weather_tool = next(tool for tool in all_tools if tool.name == "get_weather")
     result = await weather_tool.ainvoke({"location": "London"})
-    assert result == [
-        {"type": "text", "text": "It's always sunny in London", "id": IsLangChainID}
-    ]
+    assert result == [{"type": "text", "text": "It's always sunny in London"}]
 
     # Test the multiply tool
     multiply_tool = next(tool for tool in all_tools if tool.name == "multiply")
     result = await multiply_tool.ainvoke({"a": 4, "b": 5})
-    assert result == [{"type": "text", "text": "20", "id": IsLangChainID}]
+    assert result == [{"type": "text", "text": "20"}]
 
     # Test that we can call a time tool
     time_tool = next(tool for tool in all_tools if tool.name == "get_time")
     result = await time_tool.ainvoke({"args": ""})
-    assert result == [{"type": "text", "text": "5:20:00 PM EST", "id": IsLangChainID}]
+    assert result == [{"type": "text", "text": "5:20:00 PM EST"}]
 
 
 async def test_multi_server_connect_methods(
@@ -228,7 +225,7 @@ async def test_multi_server_connect_methods(
         tools = await load_mcp_tools(session)
         assert len(tools) == 2
         result = await tools[0].ainvoke({"a": 2, "b": 3})
-        assert result == [{"type": "text", "text": "5", "id": IsLangChainID}]
+        assert result == [{"type": "text", "text": "5"}]
 
         for tool in tools:
             tool_names.add(tool.name)
@@ -237,9 +234,7 @@ async def test_multi_server_connect_methods(
         tools = await load_mcp_tools(session)
         assert len(tools) == 1
         result = await tools[0].ainvoke({"args": ""})
-        assert result == [
-            {"type": "text", "text": "5:20:00 PM EST", "id": IsLangChainID}
-        ]
+        assert result == [{"type": "text", "text": "5:20:00 PM EST"}]
 
         for tool in tools:
             tool_names.add(tool.name)

--- a/tests/test_interceptors.py
+++ b/tests/test_interceptors.py
@@ -12,7 +12,7 @@ from langchain_mcp_adapters.interceptors import (
     MCPToolCallRequest,
 )
 from langchain_mcp_adapters.tools import load_mcp_tools
-from tests.utils import IsLangChainID, run_streamable_http
+from tests.utils import run_streamable_http
 
 
 def _create_math_server(port: int = 8200):
@@ -88,7 +88,7 @@ class TestInterceptorModifiesRequest:
             add_tool = next(tool for tool in tools if tool.name == "add")
             # Call add but interceptor redirects to multiply: 5 * 2 = 10
             result = await add_tool.ainvoke({"a": 5, "b": 2})
-            assert result == [{"type": "text", "text": "10", "id": IsLangChainID}]
+            assert result == [{"type": "text", "text": "10"}]
 
 
 class TestInterceptorModifiesResponse:
@@ -131,9 +131,7 @@ class TestInterceptorModifiesResponse:
 
             add_tool = next(tool for tool in tools if tool.name == "add")
             result = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result == [
-                {"type": "text", "text": "Modified: 5", "id": IsLangChainID}
-            ]
+            assert result == [{"type": "text", "text": "Modified: 5"}]
 
     async def test_interceptor_returns_custom_result(self, socket_enabled):
         """Test that interceptor can return a completely custom CallToolResult."""
@@ -160,9 +158,7 @@ class TestInterceptorModifiesResponse:
 
             add_tool = next(tool for tool in tools if tool.name == "add")
             result = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result == [
-                {"type": "text", "text": "Custom tool response", "id": IsLangChainID}
-            ]
+            assert result == [{"type": "text", "text": "Custom tool response"}]
 
 
 class TestInterceptorAdvancedPatterns:
@@ -202,17 +198,17 @@ class TestInterceptorAdvancedPatterns:
 
             # First call - should execute
             result1 = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result1 == [{"type": "text", "text": "5", "id": IsLangChainID}]
+            assert result1 == [{"type": "text", "text": "5"}]
             assert call_count == 1
 
             # Second call with same args - should use cache
             result2 = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result2 == [{"type": "text", "text": "5", "id": IsLangChainID}]
+            assert result2 == [{"type": "text", "text": "5"}]
             assert call_count == 1  # Should not increment
 
             # Third call with different args - should execute
             result3 = await add_tool.ainvoke({"a": 5, "b": 7})
-            assert result3 == [{"type": "text", "text": "12", "id": IsLangChainID}]
+            assert result3 == [{"type": "text", "text": "12"}]
             assert call_count == 2
 
 
@@ -254,7 +250,7 @@ class TestInterceptorComposition:
 
             add_tool = next(tool for tool in tools if tool.name == "add")
             result = await add_tool.ainvoke({"a": 2, "b": 3})
-            assert result == [{"type": "text", "text": "5", "id": IsLangChainID}]
+            assert result == [{"type": "text", "text": "5"}]
 
             # Should execute in onion order: 1 before, 2 before, execute, 2 after,
             # 1 after

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -35,7 +35,7 @@ from langchain_mcp_adapters.tools import (
     load_mcp_tools,
     to_fastmcp,
 )
-from tests.utils import IsLangChainID, run_streamable_http
+from tests.utils import run_streamable_http
 
 
 def test_convert_empty_text_content():
@@ -56,7 +56,7 @@ def test_convert_single_text_content():
 
     content, artifact = _convert_call_tool_result(result)
 
-    assert content == [{"type": "text", "text": "test result", "id": IsLangChainID}]
+    assert content == [{"type": "text", "text": "test result"}]
     assert artifact is None
 
 
@@ -73,8 +73,8 @@ def test_convert_multiple_text_contents():
     content, artifact = _convert_call_tool_result(result)
 
     assert content == [
-        {"type": "text", "text": "result 1", "id": IsLangChainID},
-        {"type": "text", "text": "result 2", "id": IsLangChainID},
+        {"type": "text", "text": "result 1"},
+        {"type": "text", "text": "result 2"},
     ]
     assert artifact is None
 
@@ -102,17 +102,15 @@ def test_convert_with_non_text_content():
 
     # With mixed content, we get a list of LangChain content blocks
     assert content == [
-        {"type": "text", "text": "text result", "id": IsLangChainID},
+        {"type": "text", "text": "text result"},
         {
             "type": "image",
             "base64": "base64data",
             "mime_type": "image/png",
-            "id": IsLangChainID,
         },
         {
             "type": "text",
             "text": "hi",
-            "id": IsLangChainID,
         },  # EmbeddedResource with text -> text block
     ]
     # No structuredContent in this result
@@ -141,7 +139,7 @@ def test_convert_with_structured_content():
 
     content, artifact = _convert_call_tool_result(result)
 
-    assert content == [{"type": "text", "text": "text result", "id": IsLangChainID}]
+    assert content == [{"type": "text", "text": "text result"}]
     assert artifact == MCPToolArtifact(
         structured_content={"key": "value", "nested": {"data": 123}}
     )
@@ -164,7 +162,6 @@ def test_convert_image_content():
             "type": "image",
             "base64": "jpeg_base64_data",
             "mime_type": "image/jpeg",
-            "id": IsLangChainID,
         }
     ]
     assert artifact is None
@@ -191,7 +188,6 @@ def test_convert_resource_link():
             "type": "file",
             "url": "file:///path/to/document.pdf",
             "mime_type": "application/pdf",
-            "id": IsLangChainID,
         }
     ]
     assert artifact is None
@@ -218,7 +214,6 @@ def test_convert_resource_link_image():
             "type": "image",
             "url": "https://example.com/photo.png",
             "mime_type": "image/png",
-            "id": IsLangChainID,
         }
     ]
     assert artifact is None
@@ -245,7 +240,6 @@ def test_convert_resource_link_image_jpeg():
             "type": "image",
             "url": "file:///photos/vacation.jpg",
             "mime_type": "image/jpeg",
-            "id": IsLangChainID,
         }
     ]
     assert artifact is None
@@ -273,7 +267,6 @@ def test_convert_resource_link_text():
             "type": "file",
             "url": "file:///docs/readme.txt",
             "mime_type": "text/plain",
-            "id": IsLangChainID,
         }
     ]
     assert artifact is None
@@ -298,7 +291,6 @@ def test_convert_resource_link_no_mime_type():
         {
             "type": "file",
             "url": "file:///data/unknown",
-            "id": IsLangChainID,
         }
     ]
     assert artifact is None
@@ -327,7 +319,6 @@ def test_convert_embedded_resource_blob_image():
             "type": "image",
             "base64": "png_base64_data",
             "mime_type": "image/png",
-            "id": IsLangChainID,
         }
     ]
     assert artifact is None
@@ -356,7 +347,6 @@ def test_convert_embedded_resource_blob_file():
             "type": "file",
             "base64": "pdf_base64_data",
             "mime_type": "application/pdf",
-            "id": IsLangChainID,
         }
     ]
     assert artifact is None
@@ -390,12 +380,11 @@ def test_convert_mixed_content_with_structured_content():
     content, artifact = _convert_call_tool_result(result)
 
     assert content == [
-        {"type": "text", "text": "Here's the analysis", "id": IsLangChainID},
+        {"type": "text", "text": "Here's the analysis"},
         {
             "type": "image",
             "base64": "chart_data",
             "mime_type": "image/png",
-            "id": IsLangChainID,
         },
     ]
     assert artifact == MCPToolArtifact(
@@ -447,9 +436,7 @@ async def test_convert_mcp_tool_to_langchain_tool():
     # Verify result
     assert result.name == "test_tool"
     assert result.tool_call_id == "1"
-    assert result.content == [
-        {"type": "text", "text": "tool result", "id": IsLangChainID}
-    ]
+    assert result.content == [{"type": "text", "text": "tool result"}]
 
 
 async def test_load_mcp_tools():
@@ -513,7 +500,6 @@ async def test_load_mcp_tools():
         {
             "type": "text",
             "text": "tool1 result with {'param1': 'test1', 'param2': 1}",
-            "id": IsLangChainID,
         }
     ]
 
@@ -527,7 +513,6 @@ async def test_load_mcp_tools():
         {
             "type": "text",
             "text": "tool2 result with {'param1': 'test2', 'param2': 2}",
-            "id": IsLangChainID,
         }
     ]
 
@@ -561,9 +546,7 @@ async def test_mcp_tool_error_returns_failed_tool_message():
     assert isinstance(result, ToolMessage)
     assert result.status == "error"
     assert result.tool_call_id == "1"
-    assert result.content_blocks == [
-        {"type": "text", "text": "project not found", "id": IsLangChainID}
-    ]
+    assert result.content_blocks == [{"type": "text", "text": "project not found"}]
 
 
 async def test_mcp_tool_success_returns_successful_tool_message():
@@ -583,9 +566,7 @@ async def test_mcp_tool_success_returns_successful_tool_message():
 
     assert isinstance(result, ToolMessage)
     assert result.status == "success"
-    assert result.content_blocks == [
-        {"type": "text", "text": "ok", "id": IsLangChainID}
-    ]
+    assert result.content_blocks == [{"type": "text", "text": "ok"}]
 
 
 async def test_mcp_tool_success_returns_artifact_through_ainvoke():
@@ -696,9 +677,7 @@ async def test_mcp_tool_error_empty_content_uses_fallback_message():
     result = await lc_tool_default.ainvoke(_TOOL_CALL)
     assert isinstance(result, ToolMessage)
     assert result.status == "error"
-    assert result.content_blocks == [
-        {"type": "text", "text": _EMPTY_ERROR_MESSAGE, "id": IsLangChainID}
-    ]
+    assert result.content_blocks == [{"type": "text", "text": _EMPTY_ERROR_MESSAGE}]
 
 
 async def test_mcp_tool_error_preserves_non_text_content():
@@ -752,7 +731,6 @@ async def test_mcp_tool_error_non_text_only_passes_through():
             "type": "image",
             "base64": "abc",
             "mime_type": "image/png",
-            "id": IsLangChainID,
         }
     ]
 
@@ -1022,9 +1000,7 @@ async def test_load_mcp_tools_with_custom_httpx_client_factory(socket_enabled) -
 
         # Test that the tool works correctly
         result = await tool.ainvoke({"args": {}, "id": "1", "type": "tool_call"})
-        assert result.content == [
-            {"type": "text", "text": "Server is running", "id": IsLangChainID}
-        ]
+        assert result.content == [{"type": "text", "text": "Server is running"}]
 
 
 def _create_info_server():
@@ -1403,7 +1379,6 @@ async def test_parallel_tool_invocation_across_multiple_servers(socket_enabled) 
             {
                 "type": "text",
                 "text": "Weather results for: sunny in Paris",
-                "id": IsLangChainID,
             }
         ]
 
@@ -1412,7 +1387,6 @@ async def test_parallel_tool_invocation_across_multiple_servers(socket_enabled) 
             {
                 "type": "text",
                 "text": "Flight results to: Tokyo",
-                "id": IsLangChainID,
             }
         ]
 


### PR DESCRIPTION
Fixes langchain-ai/langchain#40483.

## Summary

This strips LangChain-generated content block `id` fields from converted MCP tool result content before returning the content through the generated LangChain tool.

## Why

`langchain_core.messages.content.create_*_block(...)` generates internal block ids. Those ids are useful inside LangChain, but when MCP tool results are forwarded into Anthropic-compatible `tool_result.content`, Anthropic and Bedrock reject nested content blocks with `text.id` as an extra field.

This keeps the MCP tool output shape provider-compatible while preserving the actual text/image/file content and structured artifact behavior.

## Validation

- `python -m pytest tests/test_tools.py -q`
- `python -m ruff check langchain_mcp_adapters/tools.py tests/test_tools.py tests/test_client.py tests/test_interceptors.py`
- `git diff --check origin/main...HEAD`