### PR TITLE
test(tools): add regression tests for call_tool disconnect handling

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -455,6 +455,7 @@ def convert_mcp_tool_to_langchain_tool(
                     }
                     effective_connection = updated_connection
 
+            call_tool_result = None
             captured_exception = None
 
             if session is None:
@@ -473,8 +474,12 @@ def convert_mcp_tool_to_langchain_tool(
                             tool_args,
                             progress_callback=mcp_callbacks.progress_callback,
                         )
-                    except Exception as e:  # noqa: BLE001
-                        # Capture exception to re-raise outside context manager
+                    except BaseException as e:  # noqa: BLE001
+                        # Capture exception to re-raise outside context manager.
+                        # Must catch BaseException (not just Exception) so
+                        # asyncio.CancelledError from client disconnect is
+                        # captured before the MCP SDK context manager can
+                        # suppress it (see issue #314).
                         captured_exception = e
 
                 # Re-raise the exception outside the context manager
@@ -491,6 +496,15 @@ def convert_mcp_tool_to_langchain_tool(
                     tool_args,
                     progress_callback=mcp_callbacks.progress_callback,
                 )
+
+            if call_tool_result is None:
+                msg = (
+                    "Tool call failed: no result returned from the underlying MCP SDK. "
+                    "This may indicate that an exception was handled or suppressed "
+                    "by the MCP SDK (e.g., client disconnection, network issue, "
+                    "or other execution error)."
+                )
+                raise RuntimeError(msg)
 
             return call_tool_result
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,7 @@
+import asyncio
 import typing
-from collections.abc import Callable, Sequence
+from collections.abc import AsyncIterator, Callable, Sequence
+from contextlib import asynccontextmanager, suppress
 from typing import Annotated, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -645,6 +647,90 @@ async def test_transport_failure_still_raises():
 
     with pytest.raises(httpx.ConnectError):
         await lc_tool.ainvoke(_TOOL_CALL)
+
+
+@asynccontextmanager
+async def _swallowing_create_session(
+    call_tool_impl: Callable[..., Any],
+) -> AsyncIterator[AsyncMock]:
+    """Simulate MCP SDK create_session that suppresses exceptions on exit."""
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.call_tool = call_tool_impl
+    with suppress(BaseException):
+        yield mock_session
+
+
+async def test_call_tool_cancelled_error_not_unbound_local_error():
+    """Regression for #314: CancelledError must not cause UnboundLocalError."""
+    connection = {
+        "url": "http://localhost:8000/mcp",
+        "transport": "streamable_http",
+    }
+    mcp_tool = MCPTool(
+        name="hello", description="hello", inputSchema=_TOOL_INPUT_SCHEMA
+    )
+
+    async def raise_cancelled(*_args: object, **_kwargs: object) -> None:
+        raise asyncio.CancelledError
+
+    with patch(
+        "langchain_mcp_adapters.tools.create_session",
+        lambda *args, **kwargs: _swallowing_create_session(raise_cancelled),
+    ):
+        lc_tool = convert_mcp_tool_to_langchain_tool(
+            None, mcp_tool, connection=connection
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await lc_tool.ainvoke(_TOOL_CALL)
+
+
+async def test_call_tool_swallowed_exception_is_reraised():
+    """Exceptions suppressed by the MCP SDK context manager are re-raised."""
+    connection = {
+        "url": "http://localhost:8000/mcp",
+        "transport": "streamable_http",
+    }
+    mcp_tool = MCPTool(
+        name="hello", description="hello", inputSchema=_TOOL_INPUT_SCHEMA
+    )
+
+    async def raise_connect_error(*_args: object, **_kwargs: object) -> None:
+        raise httpx.ConnectError("connection closed")
+
+    with patch(
+        "langchain_mcp_adapters.tools.create_session",
+        lambda *args, **kwargs: _swallowing_create_session(raise_connect_error),
+    ):
+        lc_tool = convert_mcp_tool_to_langchain_tool(
+            None, mcp_tool, connection=connection
+        )
+        with pytest.raises(httpx.ConnectError, match="connection closed"):
+            await lc_tool.ainvoke(_TOOL_CALL)
+
+
+async def test_call_tool_missing_result_raises_runtime_error():
+    """If MCP SDK returns no result, surface a clear RuntimeError."""
+    connection = {
+        "url": "http://localhost:8000/mcp",
+        "transport": "streamable_http",
+    }
+    mcp_tool = MCPTool(
+        name="hello", description="hello", inputSchema=_TOOL_INPUT_SCHEMA
+    )
+
+    async def return_none(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    with patch(
+        "langchain_mcp_adapters.tools.create_session",
+        lambda *args, **kwargs: _swallowing_create_session(return_none),
+    ):
+        lc_tool = convert_mcp_tool_to_langchain_tool(
+            None, mcp_tool, connection=connection
+        )
+        with pytest.raises(RuntimeError, match="no result returned"):
+            await lc_tool.ainvoke(_TOOL_CALL)
 
 
 async def test_adapter_bug_still_raises():


### PR DESCRIPTION
## Summary

Adds unit tests requested in #314 and hardens `execute_tool` so client disconnects no longer surface as `UnboundLocalError`.

## Motivation

When a client disconnects during an MCP tool call (e.g. SSE stream cancelled), `asyncio.CancelledError` can be raised inside the MCP SDK context manager. Because `CancelledError` inherits from `BaseException` (not `Exception`), the existing `except Exception` handler did not capture it. If the SDK context manager then suppresses the error, `call_tool_result` was never assigned and callers saw `UnboundLocalError` instead of the underlying failure.

Maintainer @eyurtsev asked for a reproducible unit test in #314 after PR #318/#352.

## Changes

- Initialize `call_tool_result = None` before the per-call session path
- Capture `BaseException` (including `asyncio.CancelledError`) and re-raise outside the MCP SDK context manager
- Restore a `RuntimeError` when no tool result is returned
- Add three regression tests that simulate MCP SDK exception suppression:
  - `CancelledError` on disconnect
  - transport failures (`httpx.ConnectError`)
  - missing tool results (`None`)

## Tests

```bash
python3 -m pytest \
  tests/test_tools.py::test_call_tool_cancelled_error_not_unbound_local_error \
  tests/test_tools.py::test_call_tool_swallowed_exception_is_reraised \
  tests/test_tools.py::test_call_tool_missing_result_raises_runtime_error \
  tests/test_tools.py::test_transport_failure_still_raises \
  -v
```

All 4 tests passed locally. Full `tests/test_tools.py` suite: 44 passed, 2 skipped.

`ruff check langchain_mcp_adapters/tools.py tests/test_tools.py` — clean.

## Notes

- The tests use a small helper that simulates MCP SDK context managers swallowing exceptions on exit; this matches the failure mode described in #314 without requiring a live streamable-http server.
- `KeyboardInterrupt` / `SystemExit` are captured only to be re-raised outside the context manager, preserving existing interrupt semantics.

Fixes #314