### PR TITLE
fix(client): make get_tools gather resource-safe on partial failure

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -8,7 +8,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import TracebackType
-from typing import Any
+from typing import Any, TypeVar
 
 from langchain_core.documents.base import Blob
 from langchain_core.messages import AIMessage, HumanMessage
@@ -40,6 +40,30 @@ ASYNC_CONTEXT_MANAGER_ERROR = (
     "   async with client.session(server_name) as session:\n"
     "       tools = await load_mcp_tools(session)"
 )
+
+
+_T = TypeVar("_T")
+
+
+async def _gather_tasks_or_raise(tasks: list[asyncio.Task[_T]]) -> list[_T]:
+    """Await concurrent tasks with fail-fast semantics and no orphaned siblings.
+
+    Uses ``return_exceptions=True`` so a failing task does not abort ``gather`` while
+    sibling tasks are still running (which can leak stdio subprocesses / sockets).
+    If any task failed, cancel stragglers and re-raise the first exception.
+    """
+    if not tasks:
+        return []
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    exceptions = [result for result in results if isinstance(result, BaseException)]
+    if exceptions:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise exceptions[0]
+    return results
 
 
 class MultiServerMCPClient:
@@ -206,7 +230,7 @@ class MultiServerMCPClient:
                 )
             )
             load_mcp_tool_tasks.append(load_mcp_tool_task)
-        tools_list = await asyncio.gather(*load_mcp_tool_tasks)
+        tools_list = await _gather_tasks_or_raise(load_mcp_tool_tasks)
         for tools in tools_list:
             all_tools.extend(tools)
         return all_tools
@@ -259,7 +283,7 @@ class MultiServerMCPClient:
             asyncio.create_task(_load_resources_from_server(name))
             for name in self.connections
         ]
-        resources_list = await asyncio.gather(*load_tasks)
+        resources_list = await _gather_tasks_or_raise(load_tasks)
         for resources in resources_list:
             all_resources.extend(resources)
         return all_resources

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 from collections.abc import Generator
@@ -351,3 +352,46 @@ async def test_get_resources_from_specific_server():
     assert len(weather_resources) == 1
     assert str(weather_resources[0].metadata["uri"]) == "weather://forecast"
     assert weather_resources[0].data == "Sunny with a chance of clouds"
+
+
+async def test_get_tools_waits_for_sibling_tasks_on_failure() -> None:
+    """Sibling loaders must finish (or be cancelled) when one server fails."""
+    events: list[str] = []
+
+    async def fake_load_mcp_tools(
+        _session,
+        *,
+        connection=None,
+        server_name=None,
+        **kwargs: object,
+    ):
+        del connection, kwargs
+        if server_name == "slow":
+            await asyncio.sleep(0.05)
+            events.append("slow_done")
+            return []
+        if server_name == "fail":
+            events.append("fail")
+            msg = "stdio server unavailable"
+            raise FileNotFoundError(msg)
+        return []
+
+    client = MultiServerMCPClient(
+        {
+            "slow": {
+                "command": "python3",
+                "args": ["-c", "pass"],
+                "transport": "stdio",
+            },
+            "fail": {"command": "nope", "args": [], "transport": "stdio"},
+        }
+    )
+
+    with patch(
+        "langchain_mcp_adapters.client.load_mcp_tools",
+        side_effect=fake_load_mcp_tools,
+    ):
+        with pytest.raises(FileNotFoundError, match="stdio server unavailable"):
+            await client.get_tools()
+
+    assert events == ["fail", "slow_done"]


### PR DESCRIPTION
## Summary

Make `MultiServerMCPClient.get_tools()` and `get_resources()` resource-safe when loading from multiple MCP servers concurrently. A failing server no longer aborts `asyncio.gather` while sibling loaders are still running, which could orphan stdio subprocesses and open connections.

## Motivation

Fixes #551. The concurrent loaders previously used bare `asyncio.gather(*tasks)`, so the first failing server could leave sibling tasks mid-flight without lifecycle cleanup.

This preserves the current fail-fast semantics (re-raise the first failure) and is complementary to #495, which proposes best-effort per-server isolation for #492.

## Changes

- Add `_gather_tasks_or_raise()` helper using `gather(..., return_exceptions=True)`, cancelling any stragglers and re-raising the first exception
- Use the helper in multi-server `get_tools()` and `get_resources()`
- Add regression test ensuring a slow sibling loader completes before the aggregated failure is raised

## Tests

- `python3 -m pytest tests/test_client.py -q` — 11 passed
- composer-2.5 review: **APPROVE**

## Notes

- Maintainer preference between fail-fast (#551) and best-effort (#492/#495) may still need discussion; this PR only addresses resource safety without changing success semantics.
