### PR TITLE
fix(interceptors): annotate MCPToolCallResult as TypeAlias

### DIFF
--- a/langchain_mcp_adapters/interceptors.py
+++ b/langchain_mcp_adapters/interceptors.py
@@ -10,7 +10,7 @@ request / result lifecycle, for example to support elicitation.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 from langchain_core.messages import ToolMessage
 from mcp.types import CallToolResult
@@ -31,9 +31,9 @@ if TYPE_CHECKING:
 if LANGGRAPH_PRESENT:
     from langgraph.types import Command
 
-    MCPToolCallResult = CallToolResult | ToolMessage | Command
+    MCPToolCallResult: TypeAlias = CallToolResult | ToolMessage | Command
 else:
-    MCPToolCallResult = CallToolResult | ToolMessage
+    MCPToolCallResult: TypeAlias = CallToolResult | ToolMessage
 
 
 class _MCPToolCallRequestOverrides(TypedDict, total=False):

--- a/tests/typing/test_mcptoolcallresult_typealias.py
+++ b/tests/typing/test_mcptoolcallresult_typealias.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from langchain_mcp_adapters.interceptors import MCPToolCallResult
+
+# Type-form usages guarded by the pyright run below. If MCPToolCallResult
+# loses its TypeAlias annotation, every one of these emits
+# reportInvalidTypeForm and the test fails.
+_annotated: MCPToolCallResult | None = None
+
+
+def _accepts(value: MCPToolCallResult) -> MCPToolCallResult:
+    return value
+
+
+def _accepts_optional(value: MCPToolCallResult | None) -> MCPToolCallResult | None:
+    return value
+
+
+def _accepts_container(
+    values: list[MCPToolCallResult],
+) -> tuple[MCPToolCallResult, ...]:
+    return tuple(values)
+
+
+@pytest.mark.skipif(
+    shutil.which("pyright") is None,
+    reason="pyright not installed; skipping static type-form regression check",
+)
+def test_pyright_accepts_mcptoolcallresult_type_forms() -> None:
+    pyright = shutil.which("pyright")
+    assert pyright is not None  # narrowed by the ``skipif`` above
+
+    result = subprocess.run(  # noqa: S603
+        [pyright, "--outputjson", __file__],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, (
+        "pyright reported errors on the MCPToolCallResult type-form usages:\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
Strict Pyright/Pylance and mypy --strict rejected MCPToolCallResult in type expressions with reportInvalidTypeForm because the alias was defined by two conditional plain assignments under a runtime bool. Marking both branches with typing. TypeAlias makes it a valid type form while preserving the runtime symbol (non-breaking).

Fixes #564 