### PR TITLE
fix(tools): rename MCP args that collide with LangChain tool kwargs

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -66,6 +66,67 @@ else:
 
 MAX_ITERATIONS = 1000
 
+_LANGCHAIN_RESERVED_TOOL_ARG_NAMES = frozenset({"config", "run_manager", "callbacks"})
+_RESERVED_ARG_RENAME_SUFFIX = "__mcp_arg"
+
+
+def _adapt_mcp_input_schema(
+    input_schema: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Rename MCP args that collide with LangChain tool invocation kwargs.
+
+    Returns:
+        A tuple of the adapted JSON schema and a mapping from LangChain-visible
+        argument names back to the original MCP argument names.
+    """
+    if input_schema.get("type") != "object":
+        return input_schema, {}
+
+    properties = input_schema.get("properties")
+    if not isinstance(properties, dict):
+        return input_schema, {}
+
+    renamed_properties: dict[str, Any] = {}
+    langchain_to_mcp: dict[str, str] = {}
+    renamed_any = False
+
+    for mcp_name, property_schema in properties.items():
+        if mcp_name in _LANGCHAIN_RESERVED_TOOL_ARG_NAMES:
+            langchain_name = f"{mcp_name}{_RESERVED_ARG_RENAME_SUFFIX}"
+            renamed_any = True
+        else:
+            langchain_name = mcp_name
+        renamed_properties[langchain_name] = property_schema
+        langchain_to_mcp[langchain_name] = mcp_name
+
+    if not renamed_any:
+        return input_schema, {}
+
+    adapted_schema = dict(input_schema)
+    adapted_schema["properties"] = renamed_properties
+
+    required = input_schema.get("required")
+    if isinstance(required, list):
+        adapted_schema["required"] = [
+            (
+                f"{name}{_RESERVED_ARG_RENAME_SUFFIX}"
+                if name in _LANGCHAIN_RESERVED_TOOL_ARG_NAMES
+                else name
+            )
+            for name in required
+        ]
+
+    return adapted_schema, langchain_to_mcp
+
+
+def _map_langchain_tool_args_to_mcp(
+    arguments: dict[str, Any], langchain_to_mcp: dict[str, str]
+) -> dict[str, Any]:
+    """Map LangChain tool kwargs back to the original MCP argument names."""
+    if not langchain_to_mcp:
+        return arguments
+    return {langchain_to_mcp[key]: value for key, value in arguments.items()}
+
 
 def _summarize_tool_error(tool_content: list[ToolMessageContentBlock]) -> str:
     """Build a human-readable error message from converted error content blocks.
@@ -396,6 +457,8 @@ def convert_mcp_tool_to_langchain_tool(
         msg = "Either a session or a connection config must be provided"
         raise ValueError(msg)
 
+    adapted_input_schema, langchain_to_mcp = _adapt_mcp_input_schema(tool.inputSchema)
+
     async def call_tool(
         runtime: Annotated[object | None, InjectedToolArg()] = None,
         **arguments: dict[str, Any],
@@ -498,7 +561,7 @@ def convert_mcp_tool_to_langchain_tool(
         handler = _build_interceptor_chain(execute_tool, tool_interceptors)
         request = MCPToolCallRequest(
             name=tool.name,
-            args=arguments,
+            args=_map_langchain_tool_args_to_mcp(arguments, langchain_to_mcp),
             server_name=server_name or "unknown",
             headers=None,
             runtime=runtime,
@@ -528,7 +591,7 @@ def convert_mcp_tool_to_langchain_tool(
     return StructuredTool(
         name=lc_tool_name,
         description=tool.description or "",
-        args_schema=tool.inputSchema,
+        args_schema=adapted_input_schema,
         coroutine=call_tool,
         response_format="content_and_artifact",
         metadata=metadata,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -452,6 +452,47 @@ async def test_convert_mcp_tool_to_langchain_tool():
     ]
 
 
+@pytest.mark.parametrize("reserved_name", ["config", "run_manager", "callbacks"])
+async def test_convert_mcp_tool_renames_reserved_arguments(
+    reserved_name: str,
+) -> None:
+    """Regression for #532: preserve MCP args that collide with LangChain kwargs."""
+    session = AsyncMock()
+    session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text="ok")],
+        isError=False,
+    )
+
+    mcp_tool = MCPTool(
+        name="my_tool",
+        description="A tool with reserved argument names",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                reserved_name: {"type": "string"},
+                "query": {"type": "string"},
+            },
+            "required": [reserved_name, "query"],
+        },
+    )
+
+    lc_tool = convert_mcp_tool_to_langchain_tool(session, mcp_tool)
+    renamed_name = f"{reserved_name}__mcp_arg"
+
+    assert lc_tool.args_schema["properties"][renamed_name]["type"] == "string"
+    assert reserved_name not in lc_tool.args_schema["properties"]
+    assert renamed_name in lc_tool.args_schema["required"]
+    assert reserved_name not in lc_tool.args_schema["required"]
+
+    await lc_tool.ainvoke({renamed_name: "my_value", "query": "hello"})
+
+    session.call_tool.assert_called_once_with(
+        "my_tool",
+        {reserved_name: "my_value", "query": "hello"},
+        progress_callback=None,
+    )
+
+
 async def test_load_mcp_tools():
     tool_input_schema = {
         "properties": {


### PR DESCRIPTION
## Summary

Rename MCP tool input parameters that collide with LangChain `StructuredTool` invocation kwargs (`config`, `run_manager`, `callbacks`) in the exposed tool schema, and map them back to the original MCP names before calling the server.

## Motivation

Fixes langchain-ai/langchain#40476. When an MCP tool defines a parameter named `config`, LangChain's `StructuredTool._arun` reserves that kwarg for `RunnableConfig`, so the user's value is dropped or replaced before the MCP call.

## Changes

- Add `_adapt_mcp_input_schema()` to rename reserved MCP argument names to `{name}__mcp_arg` in the LangChain-visible JSON schema (including `required`).
- Add `_map_langchain_tool_args_to_mcp()` to restore original MCP argument names in `convert_mcp_tool_to_langchain_tool` before building `MCPToolCallRequest`.
- Add parametrized regression tests for `config`, `run_manager`, and `callbacks`.

## Tests

- `make lint` — pass
- `make test TEST_FILE=tests/test_tools.py` — 42 passed, 2 skipped

## Notes

- Models will see renamed parameters (e.g. `config__mcp_arg`) in the tool schema; values are transparently mapped back to the MCP server argument names at execution time.
- Interceptors continue to observe MCP-native argument names in `request.args`.

Fixes langchain-ai/langchain#40476