### PR TITLE
feat(tools): forward per-call _meta to session.call_tool

### DIFF
--- a/langchain_mcp_adapters/interceptors.py
+++ b/langchain_mcp_adapters/interceptors.py
@@ -46,6 +46,7 @@ class _MCPToolCallRequestOverrides(TypedDict, total=False):
     name: NotRequired[str]
     args: NotRequired[dict[str, Any]]
     headers: NotRequired[dict[str, Any] | None]
+    meta: NotRequired[dict[str, Any] | None]
 
 
 @dataclass
@@ -60,6 +61,7 @@ class MCPToolCallRequest:
         name: Tool name to invoke.
         args: Tool arguments as key-value pairs.
         headers: HTTP headers for applicable transports (SSE, HTTP).
+        meta: Request metadata forwarded as the MCP ``params._meta`` field.
 
     Context fields (read-only, use for routing/logging):
         server_name: Name of the MCP server handling the tool.
@@ -70,6 +72,7 @@ class MCPToolCallRequest:
     args: dict[str, Any]
     server_name: str  # Context: MCP server name
     headers: dict[str, Any] | None = None  # Modifiable: HTTP headers
+    meta: dict[str, Any] | None = None  # Modifiable: MCP request _meta
     runtime: object | None = None  # Context: LangGraph runtime (if any)
 
     def override(
@@ -87,6 +90,7 @@ class MCPToolCallRequest:
                 - name: Tool name
                 - args: Tool arguments
                 - headers: HTTP headers
+                - meta: MCP request metadata (``params._meta``)
 
         Returns:
             New MCPToolCallRequest instance with specified overrides

--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -435,6 +435,7 @@ def convert_mcp_tool_to_langchain_tool(
             """
             tool_name = request.name
             tool_args = request.args
+            tool_meta = request.meta
             effective_connection = connection
 
             # If headers were modified, create a new connection with updated headers
@@ -472,6 +473,7 @@ def convert_mcp_tool_to_langchain_tool(
                             tool_name,
                             tool_args,
                             progress_callback=mcp_callbacks.progress_callback,
+                            meta=tool_meta,
                         )
                     except Exception as e:  # noqa: BLE001
                         # Capture exception to re-raise outside context manager
@@ -490,6 +492,7 @@ def convert_mcp_tool_to_langchain_tool(
                     tool_name,
                     tool_args,
                     progress_callback=mcp_callbacks.progress_callback,
+                    meta=tool_meta,
                 )
 
             return call_tool_result
@@ -501,6 +504,7 @@ def convert_mcp_tool_to_langchain_tool(
             args=arguments,
             server_name=server_name or "unknown",
             headers=None,
+            meta=None,
             runtime=runtime,
         )
         call_tool_result = await handler(request)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -441,7 +441,10 @@ async def test_convert_mcp_tool_to_langchain_tool():
 
     # Verify session.call_tool was called with correct arguments
     session.call_tool.assert_called_once_with(
-        "test_tool", {"param1": "test", "param2": 42}, progress_callback=None
+        "test_tool",
+        {"param1": "test", "param2": 42},
+        progress_callback=None,
+        meta=None,
     )
 
     # Verify result
@@ -450,6 +453,78 @@ async def test_convert_mcp_tool_to_langchain_tool():
     assert result.content == [
         {"type": "text", "text": "tool result", "id": IsLangChainID}
     ]
+
+
+async def test_convert_mcp_tool_forwards_meta_from_interceptor():
+    """Test an interceptor can set the tool call meta via request.override."""
+    tool_input_schema = {
+        "properties": {},
+        "required": [],
+        "title": "EmptySchema",
+        "type": "object",
+    }
+    session = AsyncMock()
+    session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text="ok")],
+        isError=False,
+    )
+
+    mcp_tool = MCPTool(
+        name="test_tool",
+        description="Test tool description",
+        inputSchema=tool_input_schema,
+    )
+
+    async def meta_interceptor(
+        request: MCPToolCallRequest,
+        handler: Callable[[MCPToolCallRequest], typing.Awaitable[MCPToolCallResult]],
+    ) -> MCPToolCallResult:
+        return await handler(request.override(meta={"trace_id": "abc-123"}))
+
+    lc_tool = convert_mcp_tool_to_langchain_tool(
+        session, mcp_tool, tool_interceptors=[meta_interceptor]
+    )
+
+    await lc_tool.ainvoke({"args": {}, "id": "1", "type": "tool_call"})
+
+    session.call_tool.assert_called_once_with(
+        "test_tool",
+        {},
+        progress_callback=None,
+        meta={"trace_id": "abc-123"},
+    )
+
+
+async def test_convert_mcp_tool_meta_defaults_to_none():
+    """Test meta defaults to None when no interceptor sets it."""
+    tool_input_schema = {
+        "properties": {},
+        "required": [],
+        "title": "EmptySchema",
+        "type": "object",
+    }
+    session = AsyncMock()
+    session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text="ok")],
+        isError=False,
+    )
+
+    mcp_tool = MCPTool(
+        name="test_tool",
+        description="Test tool description",
+        inputSchema=tool_input_schema,
+    )
+
+    lc_tool = convert_mcp_tool_to_langchain_tool(session, mcp_tool)
+
+    await lc_tool.ainvoke({"args": {}, "id": "1", "type": "tool_call"})
+
+    session.call_tool.assert_called_once_with(
+        "test_tool",
+        {},
+        progress_callback=None,
+        meta=None,
+    )
 
 
 async def test_load_mcp_tools():
@@ -479,7 +554,7 @@ async def test_load_mcp_tools():
     session.list_tools.return_value = MagicMock(tools=mcp_tools, nextCursor=None)
 
     # Mock call_tool to return different results for different tools
-    async def mock_call_tool(tool_name, arguments, progress_callback=None):
+    async def mock_call_tool(tool_name, arguments, progress_callback=None, meta=None):
         if tool_name == "tool1":
             return CallToolResult(
                 content=[


### PR DESCRIPTION
## Summary

Adds a modifiable `meta` field to `MCPToolCallRequest` so tool-call interceptors can set the MCP `params._meta` object on `tools/call` requests. This mirrors the existing `headers` override and is forwarded to `ClientSession.call_tool(meta=...)` in both the shared-session and on-the-fly-session code paths.

## Motivation

`ClientSession.call_tool` already accepts a keyword-only `meta: dict[str, Any] | None` that populates `params._meta` on the wire. Until now `convert_mcp_tool_to_langchain_tool` never forwarded it, so there was no way to attach request-scoped metadata (e.g. tenant, trace, or correlation identifiers) to a tool call without dropping down to the raw MCP SDK. Interceptors could already modify `name`, `args`, and `headers` — this extends that same mechanism to `_meta`.

## How metadata can be propagated now

Metadata is set per tool call through a `ToolCallInterceptor`, using `request.override(meta=...)`. The interceptor runs on every tool invocation, so the value can be static or derived dynamically (for example from the LangGraph runtime available on `request.runtime`).

```python
from langchain_mcp_adapters.client import MultiServerMCPClient
from langchain_mcp_adapters.interceptors import MCPToolCallRequest, MCPToolCallResult


async def add_meta(request: MCPToolCallRequest, handler) -> MCPToolCallResult:
    # Attach MCP params._meta to every tool call.
    return await handler(request.override(meta={"trace_id": "abc-123"}))


client = MultiServerMCPClient(
    {"my_server": {"url": "http://localhost:8000/mcp", "transport": "http"}},
    tool_interceptors=[add_meta],
)

tools = await client.get_tools()
# Each tool call now sends: params._meta = {"trace_id": "abc-123"}
```

Under the hood the interceptor's `meta` flows into the tool executor and is passed straight through to the SDK:

```python
await session.call_tool(name, args, progress_callback=..., meta=request.meta)
```

which the MCP SDK serializes as `CallToolRequestParams._meta`. Servers can then read the value from the request `_meta` to implement things like multi-tenancy, request tracing, or auditing — without polluting the tool's argument schema.

## Changes

- `interceptors.py`: add `meta` to `_MCPToolCallRequestOverrides` and to the `MCPToolCallRequest` dataclass; document it in `override()`.
- `tools.py`: read `request.meta` and forward it as `meta=` to both `call_tool(...)` invocations; initialize `meta=None` on the request.
- `tests/test_tools.py`: add coverage for interceptor-set `meta` and for the default `meta=None`; update the existing exact-call assertion.

## Compatibility

Backward compatible — `meta` defaults to `None`, so existing behavior is unchanged.

## Testing

- `make lint` — passes
- `make test` — all tests pass
