### PR TITLE
fix: declare MCPToolCallResult as an explicit TypeAlias

### DIFF
--- a/langchain_mcp_adapters/interceptors.py
+++ b/langchain_mcp_adapters/interceptors.py
@@ -10,7 +10,7 @@ request / result lifecycle, for example to support elicitation.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 from langchain_core.messages import ToolMessage
 from mcp.types import CallToolResult
@@ -28,7 +28,10 @@ except ImportError:
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-if LANGGRAPH_PRESENT:
+    from langgraph.types import Command
+
+    MCPToolCallResult: TypeAlias = CallToolResult | ToolMessage | Command[Any]
+elif LANGGRAPH_PRESENT:
     from langgraph.types import Command
 
     MCPToolCallResult = CallToolResult | ToolMessage | Command


### PR DESCRIPTION
## Description

`MCPToolCallResult` was defined as two plain module-level assignments inside a runtime `if LANGGRAPH_PRESENT: / else:`, so strict type checkers rejected it in type expressions. Anyone implementing the public `ToolCallInterceptor` protocol hit `reportInvalidTypeForm` ("Variable not allowed in type expression") under Pyright/Pylance strict and had to add suppressions.

This declares the alias once under `TYPE_CHECKING` with an explicit `TypeAlias` annotation, using `Command[Any]` (an interceptor may return a `Command` routing to any node), and leaves the runtime branches unchanged — so there is no runtime behavior change.

## Verification

On the reproduction from #564 (`# pyright: strict`):

| Check | Before | After |
|---|---|---|
| pyright strict (langgraph installed) | 5 errors (`reportInvalidTypeForm` ×2, unknown types ×3) | **0 errors** |
| pyright strict (no langgraph) | 5 errors | 1 partial-unknown warning (unresolvable optional import — pre-existing limitation) |
| `mypy --strict` on the repro | clean | clean |
| `make lint` | — | passes |
| `make test` | — | 83 passed, 2 skipped (pre-existing skips) |

Fixes #564
