### PR TITLE
Pin setup-uv GitHub Action

### DIFF
--- a/.github/actions/uv_setup/action.yml
+++ b/.github/actions/uv_setup/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       with:
         version: ${{ env.UV_VERSION }}
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
## Summary
- Fixes CodeQL code-scanning alert #8 (`actions/unpinned-tag`)
- Pins `astral-sh/setup-uv` to the commit currently targeted by upstream tag `v5` (`d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86`)
- Leaves a `# v5` comment for maintainability

## Validation
- Resolved `refs/tags/v5` via GitHub API and followed the annotated tag to its commit target
- Ran `git diff --check`
- Verified only `.github/actions/uv_setup/action.yml` is changed

## Notes
- Code scanning should close the alert after this lands on `main`.