### PR TITLE
fix(interceptors): mark MCPToolCallResult as a TypeAlias for strict checkers

### DIFF
--- a/langchain_mcp_adapters/interceptors.py
+++ b/langchain_mcp_adapters/interceptors.py
@@ -10,7 +10,7 @@ request / result lifecycle, for example to support elicitation.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 from langchain_core.messages import ToolMessage
 from mcp.types import CallToolResult
@@ -28,7 +28,10 @@ except ImportError:
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-if LANGGRAPH_PRESENT:
+    from langgraph.types import Command
+
+    MCPToolCallResult: TypeAlias = CallToolResult | ToolMessage | Command
+elif LANGGRAPH_PRESENT:
     from langgraph.types import Command
 
     MCPToolCallResult = CallToolResult | ToolMessage | Command

--- a/tests/test_interceptor_types.py
+++ b/tests/test_interceptor_types.py
@@ -1,0 +1,22 @@
+"""Regression tests for MCPToolCallResult typing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from langchain_mcp_adapters.interceptors import MCPToolCallResult
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain_mcp_adapters.interceptors import MCPToolCallRequest
+
+    async def example_interceptor(
+        request: MCPToolCallRequest,
+        handler: Callable[[MCPToolCallRequest], Awaitable[MCPToolCallResult]],
+    ) -> MCPToolCallResult:
+        return await handler(request)
+
+
+def test_mcp_tool_call_result_is_exported() -> None:
+    assert MCPToolCallResult is not None


### PR DESCRIPTION
## Summary
Define `MCPToolCallResult` under `TYPE_CHECKING` with an explicit `TypeAlias` so Pyright and mypy accept it in `ToolCallInterceptor` annotations. Runtime behavior is unchanged.

## Motivation
`MCPToolCallResult` was previously assigned in competing `if LANGGRAPH_PRESENT` / `else` branches without a `TypeAlias` marker. Strict type checkers reject downstream uses such as `Callable[[MCPToolCallRequest], Awaitable[MCPToolCallResult]]` with `reportInvalidTypeForm`.

Fixes #564

## Changes
- Add a `TYPE_CHECKING` block that declares `MCPToolCallResult: TypeAlias = CallToolResult | ToolMessage | Command`
- Keep the existing runtime `elif LANGGRAPH_PRESENT` / `else` assignments for actual values
- Add `tests/test_interceptor_types.py` with a Pyright-checked interceptor signature regression fixture

## Tests
- `uv run pyright langchain_mcp_adapters/interceptors.py tests/test_interceptor_types.py` — 0 errors
- `uv run ruff check langchain_mcp_adapters/interceptors.py tests/test_interceptor_types.py` — passed
- `uv run pytest tests/test_interceptor_types.py -q` — 1 passed

## Notes
- Annotating both runtime branches with `TypeAlias` (as suggested in the issue) fixes Pyright but still triggers mypy `no-redef`; the `TYPE_CHECKING` pattern avoids that.
- CI currently runs ruff via `make lint`; Pyright was verified locally.