### PR TITLE
Warn on cross-server tool-name collisions + add server-name provenance to tool metadata

### DIFF
--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -5,6 +5,7 @@ to multiple MCP servers and loading tools, prompts, and resources from them.
 """
 
 import asyncio
+import warnings
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import TracebackType
@@ -207,7 +208,26 @@ class MultiServerMCPClient:
             )
             load_mcp_tool_tasks.append(load_mcp_tool_task)
         tools_list = await asyncio.gather(*load_mcp_tool_tasks)
-        for tools in tools_list:
+        # Surface cross-server tool-name collisions instead of merging silently.
+        # When ``tool_name_prefix`` is False, two servers can expose the same tool
+        # name; downstream tool resolution is keyed by name (the last one wins),
+        # so a later server can shadow an earlier server's tool with no signal to
+        # the caller. Warn so the collision is at least visible.
+        server_names = list(self.connections.keys())
+        first_seen: dict[str, str] = {}
+        for server, tools in zip(server_names, tools_list):
+            for tool in tools:
+                owner = first_seen.setdefault(tool.name, server)
+                if owner != server:
+                    warnings.warn(
+                        f"Tool name collision: '{tool.name}' is exposed by both "
+                        f"server '{owner}' and server '{server}'. Tool calls are "
+                        f"resolved by name (the last one wins), so one tool will "
+                        f"silently shadow the other. Pass tool_name_prefix=True to "
+                        f"MultiServerMCPClient to namespace tools by server, or give "
+                        f"the tools distinct names.",
+                        stacklevel=2,
+                    )
             all_tools.extend(tools)
         return all_tools
 

--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -510,7 +510,13 @@ def convert_mcp_tool_to_langchain_tool(
     meta = getattr(tool, "meta", None)
     base = tool.annotations.model_dump() if tool.annotations is not None else {}
     meta = {"_meta": meta} if meta is not None else {}
-    metadata = {**base, **meta} or None
+    metadata = {**base, **meta}
+    # Record the originating MCP server so agents and policy layers can attribute
+    # and disambiguate tools (e.g. when two servers expose the same tool name).
+    # Only added when the server name is known.
+    if server_name:
+        metadata["mcp_server_name"] = server_name
+    metadata = metadata or None
 
     # Apply server name prefix if requested
     lc_tool_name = tool.name

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 from collections.abc import Callable, Sequence
 from typing import Annotated, Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -880,6 +881,7 @@ async def test_load_mcp_tools_with_annotations(socket_enabled) -> None:
             "idempotentHint": False,
             "destructiveHint": None,
             "openWorldHint": None,
+            "mcp_server_name": "time",
         }
 
 
@@ -1443,9 +1445,18 @@ async def test_get_tools_with_name_conflict(socket_enabled) -> None:
             },
             tool_name_prefix=False,
         )
-        tools_no_prefix = await client_no_prefix.get_tools()
-        # Both tools are named "search" without prefix
+        # Without a prefix the collision is surfaced as a warning instead of
+        # silently merging (last-wins shadowing).
+        with pytest.warns(UserWarning, match="Tool name collision: 'search'"):
+            tools_no_prefix = await client_no_prefix.get_tools()
+        # Both tools are still named "search" without prefix
         assert all(t.name == "search" for t in tools_no_prefix)
+        # Each tool carries its originating server as provenance metadata, so a
+        # caller can still distinguish the two colliding tools.
+        assert {t.metadata["mcp_server_name"] for t in tools_no_prefix} == {
+            "weather",
+            "flights",
+        }
 
         # Now test with prefix - tools should be disambiguated
         client = MultiServerMCPClient(
@@ -1461,7 +1472,11 @@ async def test_get_tools_with_name_conflict(socket_enabled) -> None:
             },
             tool_name_prefix=True,
         )
-        tools = await client.get_tools()
+        # With prefixing there is no name collision, so no warning should fire.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            tools = await client.get_tools()
+        assert not [w for w in caught if "Tool name collision" in str(w.message)]
 
         # Verify we have both prefixed tools with unique names
         assert len(tools) == 2


### PR DESCRIPTION
This PR is a non-breaking hardening/diagnostic improvement that was discussed with the LangChain security team.

## Summary

Two small, non-breaking improvements to multi-server tool aggregation, following up on a report to the
security team (who suggested exactly these as a hardening/diagnostic enhancement):

1. **`get_tools()` warns on duplicate tool names across servers.** With `tool_name_prefix=False`, tools
   from all connected servers are merged into a flat list. Downstream tool resolution is keyed by name, so
   when two servers expose the same tool name, one silently shadows the other with no signal to the caller.
   `get_tools()` now emits a `UserWarning` identifying the two servers and pointing to `tool_name_prefix=True`.

2. **Each tool records its originating server in metadata.** `convert_mcp_tool_to_langchain_tool` now sets
   `metadata["mcp_server_name"]` (when the server name is known), so callers, logging, and policy layers can
   attribute a tool to its server — and disambiguate the two tools when names do collide.

Both are additive: default behavior is unchanged (tools are still merged; names are unchanged), and the
metadata key is new. `tool_name_prefix=True` produces no warning (no collision).

## Motivation

In a multi-server setup, `tool_name_prefix` defaults to `False`, so two servers exposing a tool with the
same name collide in the aggregated list. The merge is silent today, so an operator who adds a second
server can unknowingly shadow a tool from the first. Surfacing the collision (and recording provenance)
makes this observable without changing anyone's tool names or wiring.

## Changes

- `langchain_mcp_adapters/client.py` — `get_tools()` detects same-name tools across servers during
  aggregation and warns once per collision.
- `langchain_mcp_adapters/tools.py` — `convert_mcp_tool_to_langchain_tool` adds
  `metadata["mcp_server_name"] = server_name` when `server_name` is set.
- `tests/test_tools.py` — asserts the warning fires on a name conflict, that the two colliding tools carry
  distinct `mcp_server_name` provenance, and that **no** warning fires when `tool_name_prefix=True`
  (negative control); plus the annotations test now expects the provenance key.