### PR TITLE
fix: require opt-in for stdio env expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,26 @@ response = await agent.ainvoke({"messages": "what is the weather in nyc?"})
 
 > Only `sse` and `http` transports support runtime headers. These headers are passed with every HTTP request to the MCP server.
 
+## Stdio environment variables
+
+For `stdio` transports, `env` values are now passed through literally by
+default. If you need `${VAR}` placeholders to be expanded from the current
+process environment, opt in explicitly with `expand_env_vars=True`:
+
+```python
+client = MultiServerMCPClient(
+    {
+        "trusted_stdio_server": {
+            "transport": "stdio",
+            "command": "python",
+            "args": ["/path/to/server.py"],
+            "env": {"API_TOKEN": "${MCP_API_TOKEN}"},
+            "expand_env_vars": True,
+        },
+    }
+)
+```
+
 ## Tool error handling
 
 MCP distinguishes a tool *execution* error (`CallToolResult(isError=True)`, e.g. "project not found") from a protocol/transport failure. By default, an execution error is returned to the model as a `ToolMessage` with `status="error"`, so the agent can see what went wrong and self-correct instead of the run crashing:

--- a/langchain_mcp_adapters/sessions.py
+++ b/langchain_mcp_adapters/sessions.py
@@ -106,6 +106,13 @@ class StdioConnection(TypedDict):
     cwd: NotRequired[str | Path | None]
     """The working directory to use when spawning the process."""
 
+    expand_env_vars: NotRequired[bool]
+    """Whether `${VAR}` placeholders in `env` values should be expanded.
+
+    Defaults to `False`. Enable only when the server configuration itself is
+    trusted to reference host secrets.
+    """
+
     encoding: NotRequired[str]
     """The text encoding used when sending/receiving messages to the server.
 
@@ -216,6 +223,7 @@ async def _create_stdio_session(
     args: list[str],
     env: dict[str, str] | None = None,
     cwd: str | Path | None = None,
+    expand_env_vars: bool = False,
     encoding: str = DEFAULT_ENCODING,
     encoding_error_handler: Literal[
         "strict", "ignore", "replace"
@@ -227,17 +235,22 @@ async def _create_stdio_session(
     Args:
         command: Command to execute.
         args: Arguments for the command.
-        env: Environment variables for the command. Values containing
-            `${VAR}` references are expanded from the current environment. Only
-            braced syntax is supported; bare `${VAR}` is **not** expanded so
-            that literal dollar signs in passwords or other values are never
-            silently corrupted. Only values (not keys) are expanded;
-            `${command}` and `${args}` are passed through unchanged.
+        env: Environment variables for the command.
+
+            By default, values are passed through literally. If
+            `expand_env_vars=True`, values containing `${VAR}` references are
+            expanded from the current environment. Only braced syntax is
+            supported; bare `$VAR` is left untouched so that literal dollar
+            signs in passwords or other values are never silently corrupted.
+            Only values (not keys) are expanded; `${command}` and `${args}` are
+            passed through unchanged.
 
             If not specified, inherits a subset of the current environment.
 
             The details are implemented in the MCP sdk.
         cwd: Working directory for the command.
+        expand_env_vars: Whether `${VAR}` placeholders in `env` values should
+            be expanded using the current process environment.
         encoding: Character encoding.
         encoding_error_handler: How to handle encoding errors.
         session_kwargs: Additional keyword arguments to pass to the ClientSession.
@@ -245,9 +258,10 @@ async def _create_stdio_session(
     Yields:
         An initialized ClientSession.
     """
-    resolved_env = (
-        {k: _expand_env_vars(v) for k, v in env.items()} if env is not None else None
-    )
+    resolved_env = env
+    if env is not None and expand_env_vars:
+        resolved_env = {k: _expand_env_vars(v) for k, v in env.items()}
+
     if resolved_env is not None:
         for k, v in resolved_env.items():
             if _BRACED_VAR_RE.search(v):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,8 +43,10 @@ def mock_stdio_session() -> Generator[dict, None, None]:
         yield captured
 
 
-async def test_stdio_session_expands_env_vars(monkeypatch, mock_stdio_session):
-    """Test that ${VAR} references in the env dict are expanded before spawning."""
+async def test_stdio_session_does_not_expand_env_vars_by_default(
+    monkeypatch, mock_stdio_session
+):
+    """Env placeholders should stay literal unless expansion is explicitly enabled."""
     monkeypatch.setenv("TEST_MCP_TOKEN", "secret123")
 
     async with _create_stdio_session(
@@ -55,6 +57,30 @@ async def test_stdio_session_expands_env_vars(monkeypatch, mock_stdio_session):
             "LITERAL": "plain",
             "EMBEDDED": "Bearer ${TEST_MCP_TOKEN}",
         },
+    ):
+        pass
+
+    resolved_env = mock_stdio_session["server_params"].env
+    assert resolved_env["API_TOKEN"] == "${TEST_MCP_TOKEN}"  # noqa: S105
+    assert resolved_env["LITERAL"] == "plain"
+    assert resolved_env["EMBEDDED"] == "Bearer ${TEST_MCP_TOKEN}"
+
+
+async def test_stdio_session_expands_env_vars_when_enabled(
+    monkeypatch, mock_stdio_session
+):
+    """Trusted configs can opt in to env placeholder expansion."""
+    monkeypatch.setenv("TEST_MCP_TOKEN", "secret123")
+
+    async with _create_stdio_session(
+        command="npx",
+        args=["-y", "@some/mcp-server"],
+        env={
+            "API_TOKEN": "${TEST_MCP_TOKEN}",
+            "LITERAL": "plain",
+            "EMBEDDED": "Bearer ${TEST_MCP_TOKEN}",
+        },
+        expand_env_vars=True,
     ):
         pass
 
@@ -106,6 +132,7 @@ async def test_stdio_session_warns_on_undefined_env_var(
             command="npx",
             args=[],
             env={"SECRET": "${TOTALLY_UNDEFINED_VAR_XYZ}"},
+            expand_env_vars=True,
         ):
             pass
 


### PR DESCRIPTION
## Summary
This changes stdio session creation so `${VAR}` placeholders in `env` values are no longer expanded by default.

## Security impact
Before this patch, any workflow that imported MCP stdio connection configs from a lower-trust source could leak host environment secrets into the spawned server process by embedding placeholders such as `${OPENAI_API_KEY}`. The fix makes expansion explicit with `expand_env_vars=True`.

## Changes
- add `expand_env_vars` to `StdioConnection`
- default to literal pass-through for stdio `env` values
- keep placeholder expansion available as an explicit opt-in
- add regression tests and README guidance

## Validation
- semgrep fallback run completed with 0 findings
- manual source review confirmed the vulnerable path in `langchain_mcp_adapters/sessions.py`
- regression tests were added but not executed in this environment because only Python 3.9.6 is available while the package requires Python >=3.10

## Disclosure notes
- finding id: FIND-001
- pool: hardening
- nothing has been submitted publicly
