### PR TITLE
fix: reject duplicate MCP tool names by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ math_response = await agent.ainvoke({"messages": "what's (3 + 5) x 12?"})
 weather_response = await agent.ainvoke({"messages": "what is the weather in nyc?"})
 ```
 
+> [!important]
+> When you connect to multiple MCP servers, conflicting tool names are rejected
+> by default to avoid ambiguous tool routing. Use `tool_name_prefix=True` to
+> namespace tool names (recommended), or set `allow_duplicate_tools=True` only
+> if you explicitly trust duplicate names.
+
 > [!note]
 > Example above will start a new MCP `ClientSession` for each tool invocation. If you would like to explicitly start a session for a given server, you can do:
 >

--- a/langchain_mcp_adapters/client.py
+++ b/langchain_mcp_adapters/client.py
@@ -55,6 +55,7 @@ class MultiServerMCPClient:
         callbacks: Callbacks | None = None,
         tool_interceptors: list[ToolCallInterceptor] | None = None,
         tool_name_prefix: bool = False,
+        allow_duplicate_tools: bool = False,
         handle_tool_errors: bool = True,
     ) -> None:
         """Initialize a `MultiServerMCPClient` with MCP servers connections.
@@ -69,6 +70,9 @@ class MultiServerMCPClient:
                 using an underscore separator (e.g., `"weather_search"` instead of
                 `"search"`). This helps avoid conflicts when multiple servers have tools
                 with the same name. Defaults to `False`.
+            allow_duplicate_tools: If `True`, conflicting tool names from multiple
+                servers are returned as-is. Defaults to `False`, which rejects
+                cross-server name collisions unless `tool_name_prefix=True` is used.
             handle_tool_errors: If `True` (default), an MCP tool execution error
                 (`CallToolResult(isError=True)`) is returned to the model as a
                 `ToolMessage` with `status="error"` so the agent can self-correct
@@ -119,7 +123,36 @@ class MultiServerMCPClient:
         self.callbacks = callbacks or Callbacks()
         self.tool_interceptors = tool_interceptors or []
         self.tool_name_prefix = tool_name_prefix
+        self.allow_duplicate_tools = allow_duplicate_tools
         self.handle_tool_errors = handle_tool_errors
+
+    def _raise_on_duplicate_tool_names(self, tools_list: list[list[BaseTool]]) -> None:
+        """Reject ambiguous cross-server tool names unless explicitly allowed."""
+        if self.tool_name_prefix or self.allow_duplicate_tools:
+            return
+
+        seen: dict[str, str] = {}
+        duplicates: dict[str, set[str]] = {}
+        for server_name, tools in zip(self.connections, tools_list):
+            for tool in tools:
+                previous_server = seen.get(tool.name)
+                if previous_server is None:
+                    seen[tool.name] = server_name
+                    continue
+                duplicates.setdefault(tool.name, {previous_server}).add(server_name)
+
+        if duplicates:
+            conflicts = ", ".join(
+                f"{name} ({', '.join(sorted(servers))})"
+                for name, servers in sorted(duplicates.items())
+            )
+            msg = (
+                "Duplicate MCP tool names detected across multiple servers: "
+                f"{conflicts}. Enable `tool_name_prefix=True` to namespace tool "
+                "names, or set `allow_duplicate_tools=True` if you explicitly "
+                "trust ambiguous names."
+            )
+            raise ValueError(msg)
 
     @asynccontextmanager
     async def session(
@@ -207,6 +240,7 @@ class MultiServerMCPClient:
             )
             load_mcp_tool_tasks.append(load_mcp_tool_task)
         tools_list = await asyncio.gather(*load_mcp_tool_tasks)
+        self._raise_on_duplicate_tool_names(tools_list)
         for tools in tools_list:
             all_tools.extend(tools)
         return all_tools

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1421,7 +1421,7 @@ async def test_get_tools_with_name_conflict(socket_enabled) -> None:
     """Test fetching tools with name conflict using tool_name_prefix.
 
     This test verifies that:
-    1. Without tool_name_prefix, both servers would have conflicting "search" tool names
+    1. Without tool_name_prefix, conflicting names are rejected by default
     2. With tool_name_prefix=True, tools get unique names
         (weather_search, flights_search)
     """
@@ -1429,7 +1429,7 @@ async def test_get_tools_with_name_conflict(socket_enabled) -> None:
         run_streamable_http(_create_weather_search_server, 8185),
         run_streamable_http(_create_flights_search_server, 8186),
     ):
-        # First, verify that without prefix both tools would have the same name
+        # Conflicting names are rejected unless the caller explicitly opts in.
         client_no_prefix = MultiServerMCPClient(
             {
                 "weather": {
@@ -1443,8 +1443,24 @@ async def test_get_tools_with_name_conflict(socket_enabled) -> None:
             },
             tool_name_prefix=False,
         )
-        tools_no_prefix = await client_no_prefix.get_tools()
-        # Both tools are named "search" without prefix
+        with pytest.raises(ValueError, match="Duplicate MCP tool names detected"):
+            await client_no_prefix.get_tools()
+
+        client_allow_duplicates = MultiServerMCPClient(
+            {
+                "weather": {
+                    "url": "http://localhost:8185/mcp",
+                    "transport": "streamable_http",
+                },
+                "flights": {
+                    "url": "http://localhost:8186/mcp",
+                    "transport": "streamable_http",
+                },
+            },
+            tool_name_prefix=False,
+            allow_duplicate_tools=True,
+        )
+        tools_no_prefix = await client_allow_duplicates.get_tools()
         assert all(t.name == "search" for t in tools_no_prefix)
 
         # Now test with prefix - tools should be disambiguated


### PR DESCRIPTION
## Summary
This rejects duplicate tool names across multiple MCP servers unless the caller explicitly opts in.

## Security impact
Before this patch, `MultiServerMCPClient.get_tools()` returned ambiguous duplicate tool names whenever multiple servers exposed the same name and `tool_name_prefix` was left at its default `False`. In mixed-trust deployments, that let a malicious server impersonate a trusted tool name and receive arguments intended for another backend.

## Changes
- add `allow_duplicate_tools` as an explicit opt-in for ambiguous names
- reject duplicate tool names by default unless `tool_name_prefix=True` or `allow_duplicate_tools=True`
- add regression coverage and README guidance

## Validation
- semgrep fallback run completed with 0 findings
- manual source review confirmed the ambiguous routing path in `langchain_mcp_adapters/client.py`
- regression tests were added but not executed in this environment because only Python 3.9.6 is available while the package requires Python >=3.10

## Disclosure notes
- finding id: FIND-002
- pool: hardening
- nothing has been submitted publicly
