### PR TITLE
Add Dependabot coverage for example server

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,24 @@ updates:
         update-types:
           - "major"
 
+  - package-ecosystem: "uv"
+    directory: "/examples/servers/streamable-http-stateless"
+    schedule:
+      interval: "monthly"
+    versioning-strategy: increase
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Add monthly Dependabot `uv` coverage for the maintained `examples/servers/streamable-http-stateless` example server package root.
- Keep the update grouping and `versioning-strategy: increase` aligned with the existing root `uv` Dependabot entry.

## Validation
- Parsed `.github/dependabot.yml` with Ruby YAML.
- Ran `git diff --check`.
- Confirmed the final diff is limited to `.github/dependabot.yml`.

## Notes
- The repo's `.gitignore` covers `.env` but does not currently include broader secret patterns like `.env.*`, `*.pem`, `*.key`, `*.crt`, or `credentials.json`; I left it unchanged because this PR is scoped to Dependabot drift.