### PR TITLE
release: 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "langchain-mcp-adapters"
-version = "0.3.0"
+version = "0.3.1"
 description = "Make Anthropic Model Context Protocol (MCP) tools compatible with LangChain and LangGraph agents."
 authors = [
     { name = "Vadym Barda", email = "19161700+vbarda@users.noreply.github.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=1.3.3,<2.0.0",
-    "mcp>=1.9.2",
+    "mcp>=1.24.0",
     "typing-extensions>=4.14.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -499,7 +499,7 @@ wheels = [
 
 [[package]]
 name = "langchain-mcp-adapters"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },

--- a/uv.lock
+++ b/uv.lock
@@ -526,7 +526,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", specifier = ">=1.3.3,<2.0.0" },
-    { name = "mcp", specifier = ">=1.9.2" },
+    { name = "mcp", specifier = ">=1.24.0" },
     { name = "typing-extensions", specifier = ">=4.14.0" },
 ]
 


### PR DESCRIPTION
## Summary

Patch release for `langchain-mcp-adapters`.

Notable changes since 0.3.0:
- `get_server_info` to retrieve MCP server metadata (#430)
- Raise `mcp` minimum version from `>=1.9.2` to `>=1.24.0` so installs pull a version that exports `streamable_http_client` and `ElicitationFnT` (fixes #550; supersedes #553)

Also includes dependency and CI maintenance updates.

## After merge

Run the `release` workflow from `main` to publish to PyPI and create the GitHub release tag (`langchain-mcp-adapters==0.3.1`).

Fixes #550
