### PR TITLE
fix: constrain MCP SDK to v1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "langchain-core>=1.3.3,<2.0.0",
-    "mcp>=1.24.0",
+    "mcp>=1.24.0,<2.0.0",
     "typing-extensions>=4.14.0",
 ]
 
@@ -117,4 +117,3 @@ check_untyped_defs = true
     "C901", # Function is too complex
 
 ]
-

--- a/uv.lock
+++ b/uv.lock
@@ -526,7 +526,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", specifier = ">=1.3.3,<2.0.0" },
-    { name = "mcp", specifier = ">=1.24.0" },
+    { name = "mcp", specifier = ">=1.24.0,<2.0.0" },
     { name = "typing-extensions", specifier = ">=4.14.0" },
 ]
 


### PR DESCRIPTION
## Summary

- constrain the `mcp` dependency to `<2.0.0`
- update the lockfile metadata to match

## Context

MCP Python SDK 2.0.0 contains breaking API changes. Since the current requirement is `mcp>=1.24.0`, fresh installations now resolve 2.0.0 and `langchain-mcp-adapters` fails during import:

> ImportError: cannot import name `RequestContext` from `mcp.shared.context`

The adapter currently uses MCP v1 APIs, so constrain it to v1 until MCP v2 support is implemented. This addresses the immediate installation regression discussed in #578 without closing the broader v2-support request.

## Testing

- `make lint`
- `make test` (96 passed, 2 skipped)