### PR TITLE
fix(tools): represent ResourceLink as text instead of URL file blocks

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -172,7 +172,27 @@ class MCPToolArtifact(TypedDict):
     structured_content: dict[str, Any]
 
 
-def _convert_mcp_content_to_lc_block(  # noqa: PLR0911
+def _resource_link_to_text_block(content: ResourceLink) -> TextContentBlock:
+    """Represent an MCP ResourceLink as text instead of a URL file block.
+
+    ResourceLinks are pointers to MCP resources that must be fetched via
+    ``resources/read`` on the MCP session. They are not dereferenceable URLs,
+    and mapping them onto URL-based file/image blocks breaks providers (e.g.
+    Bedrock) that only accept inline bytes.
+    """
+    label = content.title or content.name or str(content.uri)
+    lines = [f"Resource link: {label}", f"URI: {content.uri}"]
+    mime_type = content.mimeType or None
+    if mime_type:
+        lines.append(f"MIME type: {mime_type}")
+    if content.description:
+        lines.append(f"Description: {content.description}")
+    if content.size is not None:
+        lines.append(f"Size: {content.size}")
+    return create_text_block(text="\n".join(lines))
+
+
+def _convert_mcp_content_to_lc_block(
     content: ContentBlock,
 ) -> ToolMessageContentBlock:
     """Convert any MCP content block to a LangChain content block.
@@ -202,10 +222,7 @@ def _convert_mcp_content_to_lc_block(  # noqa: PLR0911
         raise NotImplementedError(msg)
 
     if isinstance(content, ResourceLink):
-        mime_type = content.mimeType or None
-        if mime_type and mime_type.startswith("image/"):
-            return create_image_block(url=str(content.uri), mime_type=mime_type)
-        return create_file_block(url=str(content.uri), mime_type=mime_type)
+        return _resource_link_to_text_block(content)
 
     if isinstance(content, EmbeddedResource):
         resource = content.resource
@@ -231,8 +248,7 @@ def _convert_call_tool_result(
     Converts MCP content blocks to LangChain content blocks:
     - TextContent -> {"type": "text", "text": ...}
     - ImageContent -> {"type": "image", "base64": ..., "mime_type": ...}
-    - ResourceLink (image/*) -> {"type": "image", "url": ..., "mime_type": ...}
-    - ResourceLink (other) -> {"type": "file", "url": ..., "mime_type": ...}
+    - ResourceLink -> {"type": "text", "text": ...} (resource reference metadata)
     - EmbeddedResource (text) -> {"type": "text", "text": ...}
     - EmbeddedResource (blob) -> {"type": "image", ...} or {"type": "file", ...}
     - AudioContent -> raises NotImplementedError

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -31,6 +31,7 @@ from langchain_mcp_adapters.interceptors import MCPToolCallRequest, MCPToolCallR
 from langchain_mcp_adapters.tools import (
     MCPToolArtifact,
     _convert_call_tool_result,
+    _convert_mcp_content_to_lc_block,
     convert_mcp_tool_to_langchain_tool,
     load_mcp_tools,
     to_fastmcp,
@@ -171,7 +172,7 @@ def test_convert_image_content():
 
 
 def test_convert_resource_link():
-    """Test ResourceLink conversion to LangChain file block for non-image types."""
+    """Test ResourceLink conversion to a text block for non-image types."""
     result = CallToolResult(
         content=[
             ResourceLink(
@@ -188,9 +189,12 @@ def test_convert_resource_link():
 
     assert content == [
         {
-            "type": "file",
-            "url": "file:///path/to/document.pdf",
-            "mime_type": "application/pdf",
+            "type": "text",
+            "text": (
+                "Resource link: document.pdf\n"
+                "URI: file:///path/to/document.pdf\n"
+                "MIME type: application/pdf"
+            ),
             "id": IsLangChainID,
         }
     ]
@@ -198,7 +202,7 @@ def test_convert_resource_link():
 
 
 def test_convert_resource_link_image():
-    """Test ResourceLink with image mime type converts to image block with URL."""
+    """Test ResourceLink with image mime type converts to a text block."""
     result = CallToolResult(
         content=[
             ResourceLink(
@@ -215,9 +219,12 @@ def test_convert_resource_link_image():
 
     assert content == [
         {
-            "type": "image",
-            "url": "https://example.com/photo.png",
-            "mime_type": "image/png",
+            "type": "text",
+            "text": (
+                "Resource link: photo.png\n"
+                "URI: https://example.com/photo.png\n"
+                "MIME type: image/png"
+            ),
             "id": IsLangChainID,
         }
     ]
@@ -225,7 +232,7 @@ def test_convert_resource_link_image():
 
 
 def test_convert_resource_link_image_jpeg():
-    """Test ResourceLink with JPEG image mime type converts to image block."""
+    """Test ResourceLink with JPEG image mime type converts to a text block."""
     result = CallToolResult(
         content=[
             ResourceLink(
@@ -242,9 +249,12 @@ def test_convert_resource_link_image_jpeg():
 
     assert content == [
         {
-            "type": "image",
-            "url": "file:///photos/vacation.jpg",
-            "mime_type": "image/jpeg",
+            "type": "text",
+            "text": (
+                "Resource link: vacation.jpg\n"
+                "URI: file:///photos/vacation.jpg\n"
+                "MIME type: image/jpeg"
+            ),
             "id": IsLangChainID,
         }
     ]
@@ -252,7 +262,7 @@ def test_convert_resource_link_image_jpeg():
 
 
 def test_convert_resource_link_text():
-    """Test ResourceLink with text mime type converts to file block (can't inline)."""
+    """Test ResourceLink with text mime type converts to a text block."""
     result = CallToolResult(
         content=[
             ResourceLink(
@@ -267,12 +277,14 @@ def test_convert_resource_link_text():
 
     content, artifact = _convert_call_tool_result(result)
 
-    # Text ResourceLinks become file blocks since we only have URL, not content
     assert content == [
         {
-            "type": "file",
-            "url": "file:///docs/readme.txt",
-            "mime_type": "text/plain",
+            "type": "text",
+            "text": (
+                "Resource link: readme.txt\n"
+                "URI: file:///docs/readme.txt\n"
+                "MIME type: text/plain"
+            ),
             "id": IsLangChainID,
         }
     ]
@@ -280,7 +292,7 @@ def test_convert_resource_link_text():
 
 
 def test_convert_resource_link_no_mime_type():
-    """Test ResourceLink without mime type converts to file block."""
+    """Test ResourceLink without mime type converts to a text block."""
     result = CallToolResult(
         content=[
             ResourceLink(
@@ -296,12 +308,28 @@ def test_convert_resource_link_no_mime_type():
 
     assert content == [
         {
-            "type": "file",
-            "url": "file:///data/unknown",
+            "type": "text",
+            "text": "Resource link: unknown\nURI: file:///data/unknown",
             "id": IsLangChainID,
         }
     ]
     assert artifact is None
+
+
+def test_convert_resource_link_custom_scheme():
+    """Regression: non-dereferenceable MCP URIs must not become URL file blocks."""
+    link = ResourceLink(
+        type="resource_link",
+        uri="demo://resource/dynamic/blob/1",
+        name="Resource 1",
+        mimeType="text/plain",
+    )
+
+    block = _convert_mcp_content_to_lc_block(link)
+
+    assert block["type"] == "text"
+    assert "demo://resource/dynamic/blob/1" in block["text"]
+    assert "url" not in block
 
 
 def test_convert_embedded_resource_blob_image():


### PR DESCRIPTION
## Summary

Convert MCP `ResourceLink` content blocks to text blocks with resource metadata instead of URL-based file/image blocks.

## Motivation

Fixes langchain-ai/langchain#40475.

`ResourceLink` values are pointers that must be fetched via `resources/read` on the MCP session — they are not dereferenceable URLs. The previous conversion mapped them onto `file`/`image` blocks with a `url` field, which:

1. **Breaks Bedrock** — Converse only accepts inline bytes for documents, so a single `ResourceLink` in a tool result causes `ValueError: File data only supported through in-line base64 format.` and terminates the agent run.
2. **Misrepresents custom URI schemes** — Servers commonly return URIs like `demo://resource/dynamic/blob/1` that no provider can fetch as HTTP URLs.

## Changes

- Add `_resource_link_to_text_block()` helper that formats resource metadata as human-readable text.
- Update `_convert_mcp_content_to_lc_block()` to use text blocks for all `ResourceLink` values.
- Update existing ResourceLink tests and add a regression test for custom-scheme URIs.

**Breaking change:** `ResourceLink` no longer produces `file`/`image` blocks with `url`. Downstream code expecting URL blocks for resource links will need to adapt. This is intentional — the old behavior was incorrect for MCP semantics and incompatible with Bedrock.

## Tests

```bash
python3 -m pytest tests/test_tools.py -q
# 42 passed, 2 skipped
```

Verified the issue's Bedrock reproduction path: converted blocks are `type: text` with no `url` field.

## Notes

- `EmbeddedResource` handling is unchanged — those still inline actual content via base64/text.
- Auto-fetching resources via `resources/read` is out of scope (would require session context not available at conversion time).