### PR TITLE
fix: support sync StructuredTool.invoke for MCP tools

### DIFF
--- a/langchain_mcp_adapters/tools.py
+++ b/langchain_mcp_adapters/tools.py
@@ -4,8 +4,12 @@ This module provides functionality to convert MCP tools into LangChain-compatibl
 tools, handle tool execution, and manage tool conversion between the two formats.
 """
 
+from __future__ import annotations
+
+import asyncio
 from collections.abc import Awaitable, Callable
-from typing import Annotated, Any, TypedDict, get_args
+from concurrent.futures import ThreadPoolExecutor
+from typing import Annotated, Any, TypedDict, TypeVar, get_args
 
 from langchain_core.messages import ToolMessage
 from langchain_core.messages.content import (
@@ -65,6 +69,51 @@ else:
     ConvertedToolResult = list[ToolMessageContentBlock] | ToolMessage
 
 MAX_ITERATIONS = 1000
+
+_T = TypeVar("_T")
+
+
+def _run_coroutine_sync(
+    coro_factory: Callable[[], Awaitable[_T]],
+    *,
+    allow_thread_hop: bool,
+) -> _T:
+    """Run an async callable from synchronous code.
+
+    Args:
+        coro_factory: Zero-arg factory that creates a fresh coroutine each call.
+            The factory is invoked in the event loop that will execute it so the
+            coroutine is never bound to the wrong loop.
+        allow_thread_hop: When an event loop is already running, whether it is safe
+            to execute the coroutine on a new loop in a worker thread. Connection-
+            based MCP tools can do this; tools that captured an active session
+            cannot, because that session is bound to the original loop.
+
+    Returns:
+        The coroutine result.
+
+    Raises:
+        NotImplementedError: If a loop is already running and thread-hopping is
+            not allowed for this tool.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro_factory())
+
+    if not allow_thread_hop:
+        msg = (
+            "MCP tools bound to an active ClientSession cannot be invoked "
+            "synchronously while an event loop is running. Use "
+            "`await tool.ainvoke(...)` / `await agent.ainvoke(...)`, or load tools "
+            "via a connection config (for example `MultiServerMCPClient.get_tools()`) "
+            "so each call can open its own session."
+        )
+        raise NotImplementedError(msg)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(lambda: asyncio.run(coro_factory()))
+        return future.result()
 
 
 def _summarize_tool_error(tool_content: list[ToolMessageContentBlock]) -> str:
@@ -507,6 +556,16 @@ def convert_mcp_tool_to_langchain_tool(
 
         return _convert_call_tool_result(call_tool_result)
 
+    def call_tool_sync(
+        runtime: Annotated[object | None, InjectedToolArg()] = None,
+        **arguments: dict[str, Any],
+    ) -> tuple[ConvertedToolResult, MCPToolArtifact | None]:
+        """Synchronous wrapper around the async MCP tool call."""
+        return _run_coroutine_sync(
+            lambda: call_tool(runtime=runtime, **arguments),
+            allow_thread_hop=session is None,
+        )
+
     meta = getattr(tool, "meta", None)
     base = tool.annotations.model_dump() if tool.annotations is not None else {}
     meta = {"_meta": meta} if meta is not None else {}
@@ -529,6 +588,7 @@ def convert_mcp_tool_to_langchain_tool(
         name=lc_tool_name,
         description=tool.description or "",
         args_schema=tool.inputSchema,
+        func=call_tool_sync,
         coroutine=call_tool,
         response_format="content_and_artifact",
         metadata=metadata,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -452,6 +452,130 @@ async def test_convert_mcp_tool_to_langchain_tool():
     ]
 
 
+def test_convert_mcp_tool_supports_sync_invoke_without_running_loop():
+    """Connection-based tools expose a sync `func` for StructuredTool.invoke()."""
+    tool_input_schema = {
+        "properties": {
+            "param1": {"title": "Param1", "type": "string"},
+            "param2": {"title": "Param2", "type": "integer"},
+        },
+        "required": ["param1", "param2"],
+        "title": "ToolSchema",
+        "type": "object",
+    }
+    mcp_tool = MCPTool(
+        name="test_tool",
+        description="Test tool description",
+        inputSchema=tool_input_schema,
+    )
+    mock_session = AsyncMock()
+    mock_session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text="sync tool result")],
+        isError=False,
+    )
+    mock_session.initialize = AsyncMock()
+
+    # Fake async context manager returned by create_session
+    session_cm = AsyncMock()
+    session_cm.__aenter__.return_value = mock_session
+    session_cm.__aexit__.return_value = None
+
+    with patch(
+        "langchain_mcp_adapters.tools.create_session",
+        return_value=session_cm,
+    ):
+        lc_tool = convert_mcp_tool_to_langchain_tool(
+            None,
+            mcp_tool,
+            connection={
+                "transport": "stdio",
+                "command": "echo",
+                "args": [],
+            },
+        )
+        assert lc_tool.func is not None
+        assert lc_tool.coroutine is not None
+
+        result = lc_tool.invoke(
+            {"args": {"param1": "test", "param2": 42}, "id": "1", "type": "tool_call"},
+        )
+
+    mock_session.call_tool.assert_called_once_with(
+        "test_tool", {"param1": "test", "param2": 42}, progress_callback=None
+    )
+    assert result.content == [
+        {"type": "text", "text": "sync tool result", "id": IsLangChainID}
+    ]
+
+
+async def test_convert_mcp_tool_sync_invoke_from_async_context_connection_based():
+    """Sync invoke works from a running loop when tools use a connection config."""
+    tool_input_schema = {
+        "properties": {"param1": {"title": "Param1", "type": "string"}},
+        "required": ["param1"],
+        "title": "ToolSchema",
+        "type": "object",
+    }
+    mcp_tool = MCPTool(
+        name="test_tool",
+        description="Test tool description",
+        inputSchema=tool_input_schema,
+    )
+    mock_session = AsyncMock()
+    mock_session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text="thread-hop result")],
+        isError=False,
+    )
+    mock_session.initialize = AsyncMock()
+    session_cm = AsyncMock()
+    session_cm.__aenter__.return_value = mock_session
+    session_cm.__aexit__.return_value = None
+
+    with patch(
+        "langchain_mcp_adapters.tools.create_session",
+        return_value=session_cm,
+    ):
+        lc_tool = convert_mcp_tool_to_langchain_tool(
+            None,
+            mcp_tool,
+            connection={
+                "transport": "stdio",
+                "command": "echo",
+                "args": [],
+            },
+        )
+        # Calling sync invoke while this async test has a running loop.
+        result = lc_tool.invoke(
+            {"args": {"param1": "test"}, "id": "2", "type": "tool_call"},
+        )
+
+    assert result.content == [
+        {"type": "text", "text": "thread-hop result", "id": IsLangChainID}
+    ]
+
+
+async def test_convert_mcp_tool_sync_invoke_session_bound_while_loop_running():
+    """Session-bound tools refuse unsafe sync invoke while a loop is running."""
+    tool_input_schema = {
+        "properties": {"param1": {"title": "Param1", "type": "string"}},
+        "required": ["param1"],
+        "title": "ToolSchema",
+        "type": "object",
+    }
+    session = AsyncMock()
+    mcp_tool = MCPTool(
+        name="test_tool",
+        description="Test tool description",
+        inputSchema=tool_input_schema,
+    )
+    lc_tool = convert_mcp_tool_to_langchain_tool(session, mcp_tool)
+
+    with pytest.raises(NotImplementedError, match="active ClientSession"):
+        lc_tool.invoke(
+            {"args": {"param1": "test"}, "id": "3", "type": "tool_call"},
+        )
+
+
 async def test_load_mcp_tools():
     tool_input_schema = {
         "properties": {


### PR DESCRIPTION
Fixes #576

MCP tools created by this library only set `coroutine` on `StructuredTool`. Sync paths such as `create_react_agent(...).invoke()` call `tool.run()` / `_run()`, which requires `func`, and previously raised `NotImplementedError: StructuredTool does not support sync invocation`.

This adds a sync `func` that bridges to the existing async tool call:
- No running event loop → `asyncio.run(...)`
- Running loop + connection-based tools (`session is None`) → worker thread with a fresh loop (covers the common `MultiServerMCPClient.get_tools()` then `agent.invoke()` pattern)
- Running loop + session-bound tools → clear `NotImplementedError` directing callers to `ainvoke` or connection-based loading

Verified with `make test` (101 passed), including new sync-invoke coverage in `tests/test_tools.py`.